### PR TITLE
recoveryEmail should call templates recoveryEmail

### DIFF
--- a/mailer.js
+++ b/mailer.js
@@ -102,7 +102,7 @@ module.exports = function (log) {
       code: message.code
     }
 
-    var localized = this.templates.verifyEmail(values)
+    var localized = this.templates.recoveryEmail(values)
     var email = {
       sender: this.sender,
       to: message.email,


### PR DESCRIPTION
I was adding tests and coverage, and that pointed out this error. While the
subject on the outgoing email was correct ('Reset your password'), as was the
link in the content (/complete_reset_password), the body text was about
signing up, not resetting a password. So, usable, but for some number of
users, it might be somewhat confusing.

I think we should consider picking this up in train-14 (before it goes live
Monday afternoon). /cc @ckolos, @ckarlof
