### PR TITLE
Update package.json with the repo info.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,12 @@
     "test": "tap test/local"
   },
   "author": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dannycoates/fxa-auth-mailer"
+  },
+  "homepage": "https://github.com/dannycoates/fxa-auth-mailer",
+  "bugs": "https://github.com/dannycoates/fxa-auth-mailer/issues",
   "license": "MPL 2.0",
   "dependencies": {
     "bluebird": "2.2.2",


### PR DESCRIPTION
This is to make it slightly easier for newcomers to the auth server who are trying to figure out where the email code lives.
