### PR TITLE
Use new, shorter sender address on verification emails

### DIFF
--- a/config.js
+++ b/config.js
@@ -8,7 +8,7 @@ module.exports = require('rc')(
       host: '127.0.0.1',
       port: 9999,
       secure: false,
-      sender: 'verification@accounts.firefox.com',
+      sender: 'accounts@firefox.com',
       verificationUrl: 'https://accounts.firefox.com/v1/verify_email',
       passwordResetUrl: 'https://accounts.firefox.com/v1/complete_reset_password',
       accountUnlockUrl: 'https://accounts.firefox.com/v1/complete_unlock_account'


### PR DESCRIPTION
This updates the defailt sender to match what's suggested in https://github.com/mozilla/fxa-auth-server/issues/841#issuecomment-75295048

I'm not sure if this local config value is actually used in our current setup, but it seems wise to keep things consistent.  @dannycoates r?