### PR TITLE
add auth obj in options if set in config

### DIFF
--- a/mailer.js
+++ b/mailer.js
@@ -14,6 +14,14 @@ module.exports = function (log) {
       secureConnection: config.secure,
       port: config.port
     }
+
+    if (config.user && config.password) {
+      options.auth = {
+        user: config.user,
+        pass: config.password
+      }
+    }
+    
     this.mailer = nodemailer.createTransport('SMTP', options)
     this.sender = config.sender
     this.verificationUrl = config.verificationUrl


### PR DESCRIPTION
in local development, I've updated `/fxa-auth-server/config/dev.json`. adding into smtp, `user` and `password` as they are by default `undefined` (trying to use smtp from Gandi.net)

but I've received `RecipientError` `Client host rejected: Access denied` by the server

Then I saw that these prop in config are not used in nodemailer when it is called.. that's why I've added the `auth` config.