### PR TITLE
fix(l10n): make defaultLanguage configurable, and switch to "en" default

### DIFF
--- a/config.js
+++ b/config.js
@@ -3,7 +3,8 @@ module.exports = require('rc')(
   {
     port: 1810,
     logLevel: 'info',
-    locales: ['en_US', 'de'],
+    locales: ['en', 'de'],
+    defaultLanguage: 'en'
     mail: {
       host: '127.0.0.1',
       port: 9999,

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = function (log, config) {
   var Mailer = createMailer(log)
   return P.all(
     [
-      require('./translator')(config.locales),
+      require('./translator')(config.locales, config.defaultLanguage),
       require('./templates')()
     ]
   )

--- a/test/local/translator_tests.js
+++ b/test/local/translator_tests.js
@@ -1,6 +1,6 @@
 var test = require('tap').test
 
-require('../../translator')(['en_US','pt_br', 'DE', 'ES_AR', 'ES_cl'])
+require('../../translator')(['en','pt_br', 'DE', 'ES_AR', 'ES_cl'], 'en')
 .done(
   function (translator) {
     test(
@@ -12,6 +12,10 @@ require('../../translator')(['en_US','pt_br', 'DE', 'ES_AR', 'ES_cl'])
         t.equal(x.language, 'es-AR')
         x = translator('es-CL')
         t.equal(x.language, 'es-CL')
+        x = translator('en-US')
+        t.equal(x.language, 'en')
+        x = translator('db-LB') // a locale that does not exist
+        t.equal(x.language, 'en')
         t.end()
       }
     )

--- a/translator.js
+++ b/translator.js
@@ -7,7 +7,7 @@ var poParseFile = P.promisify(po2json.parseFile)
 
 Jed.prototype.format = i18n.format
 
-module.exports = function (locales) {
+module.exports = function (locales, defaultLanguage) {
   return P.all(
     locales.map(
       function (locale) {
@@ -38,9 +38,10 @@ module.exports = function (locales) {
         translator.language = language
         languageTranslations[language] = translator
       }
+
       return function translator(acceptLanguage) {
         var languages = i18n.parseAcceptLanguage(acceptLanguage)
-        var best = i18n.normalizeLanguage(i18n.bestLanguage(languages, supportedLanguages, 'en-US'))
+        var best = i18n.normalizeLanguage(i18n.bestLanguage(languages, supportedLanguages, defaultLanguage))
         return languageTranslations[best]
       }
     }


### PR DESCRIPTION
This adjusts the defaultLanguage from 'en-US' to 'en' and makes that sorta configurable. 
I don't particularly like the `config.i18n` part, since that's a detail from fxa-auth-server. 