### PR TITLE
feat(signup): add schema.org one-click-action button to verify email

### DIFF
--- a/mailer.js
+++ b/mailer.js
@@ -69,10 +69,13 @@ module.exports = function (log) {
     if (message.resume) { query.resume = message.resume }
 
     var link = this.verificationUrl + '?' + qs.stringify(query)
+    query.one_click = true
+    var oneClickLink = this.verificationUrl + '?' + qs.stringify(query)
 
     var values = {
       translator: translator,
       link: link,
+      oneClickLink: oneClickLink,
       email: message.email
     }
     var localized = this.templates.verifyEmail(values)

--- a/templates/verify.html
+++ b/templates/verify.html
@@ -31,6 +31,14 @@
     </style>
   </head>
   <body leftmargin="0" marginwidth="0" topmargin="0" marginheight="0" offset="0" style="background-color:#F2F2F2;width:100% !important;height:100% !important;padding:0;margin:0;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;">
+    <div itemscope itemtype="https://schema.org/EmailMessage">
+      <div itemprop="potentialAction" itemscope itemtype="https://schema.org/ViewAction">
+        <link itemprop="target" href="{{{oneClickLink}}}"/>
+        <meta itemprop="name" content="{{t 'Verify Email'}}"/>
+        <meta itemprop="url" content="{{{oneClickLink}}}"/>
+      </div>
+      <meta itemprop="description" content="{{t 'Verify your email to finish your Firefox Account registration'}}" />
+    </div>
     <center>
       <table align="center" border="0" cellpadding="0" cellspacing="0" height="100%" width="100%" id="bodyTable" style="background-color:#F2F2F2;width:100% !important;padding:0;margin:0;height:100% !important;border-collapse:collapse !important;mso-table-rspace:0pt;mso-table-lspace:0pt;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;">
         <tr>


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa-auth-mailer/issues/36.

![screen shot 2015-06-04 at 5 10 44 pm](https://cloud.githubusercontent.com/assets/6424575/7997132/592002d8-0add-11e5-9667-e17f39a200da.png)
Right now to test it you have to copy-paste the email HTML code [here](http://gmail-actions.appspot.com/).

I think maybe @jrgm will have to [register to Google](https://developers.google.com/gmail/markup/registering-with-google) to make it work on production servers.