### PR TITLE
fix(locales): always normalize the locale

### DIFF
--- a/translator.js
+++ b/translator.js
@@ -32,7 +32,7 @@ module.exports = function (locales, defaultLanguage) {
       var supportedLanguages = []
       for (var i = 0; i < translations.length; i++) {
         var t = translations[i]
-        var language = i18n.languageFrom(t.locale_data.messages[""].lang)
+        var language = i18n.normalizeLanguage(i18n.languageFrom(t.locale_data.messages[""].lang))
         supportedLanguages.push(language)
         var translator = new Jed(t)
         translator.language = language


### PR DESCRIPTION
So this fixes the issue noted in https://github.com/mozilla/fxa-auth-mailer/pull/46#issuecomment-111657709 and https://github.com/mozilla/fxa-content-server-l10n/issues/52

(This whole 'upper-case or lower-case', '- or _', '2 or 3 or 4 character' language and/or country-code is fugly).