### PR TITLE
Append "now" to verify/reset password button CTAs

### DIFF
--- a/templates/reset.html
+++ b/templates/reset.html
@@ -66,7 +66,7 @@
                                           <w:anchorlock/>
                                           <center>
                                             <![endif]-->
-                                            <a href="{{{link}}}" style="text-decoration:none;font-size:20px;font-family:Helvetica;display:block;color:#FFFFFF;padding:15px !important;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;">{{t "Reset password"}}</a>
+                                            <a href="{{{link}}}" style="text-decoration:none;font-size:20px;font-family:Helvetica;display:block;color:#FFFFFF;padding:15px !important;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;">{{t "Reset password now"}}</a>
                                           <!--[if mso]>
                                           </center>
                                           </v:roundrect>

--- a/templates/reset.txt
+++ b/templates/reset.txt
@@ -1,6 +1,6 @@
 {{t "Are you sure?"}}
 
 {{{t "Please confirm that you'd like to reset the password for %(email)s." }}}
-{{t "Reset password:"}} {{{link}}}
+{{t "Reset password now:"}} {{{link}}}
 
 {{t "This is an automated email; if you received it in error, no action is required."}} {{t "For more information, please visit https://support.mozilla.org"}}


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa-auth-server/issues/881.

That issue only mentions the buttons, so I've not made the change in the text templates. Is that right/wrong?