### PR TITLE
fix(templates): disable HTML escaping of Android/iOS product links.

### DIFF
--- a/templates/post_verify.html
+++ b/templates/post_verify.html
@@ -22,7 +22,7 @@
             <tr>
               <td valign="top">
                 <h1 style="font-family: sans-serif; font-weight: normal; margin: 0 0 24px 0; text-align: center;">{{t "Account verified!" }}</h1>
-                <p class="primary" style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 24px 0; text-align: center; width: 310px;">{{t "You successfully connected your first device to your Firefox Account. Now you can sign in to Sync from your other devices, including Firefox for <a href='%(androidUrl)s'>Android</a> and <a href='%(iosUrl)s'>iOS</a>." }}</p>
+                <p class="primary" style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 24px 0; text-align: center; width: 310px;">{{{t "You successfully connected your first device to your Firefox Account. Now you can sign in to Sync from your other devices, including Firefox for <a href='%(androidUrl)s'>Android</a> and <a href='%(iosUrl)s'>iOS</a>." }}}</p>
               </td>
             </tr>
 


### PR DESCRIPTION
Fixes #80.  @dannycoates r?