### PR TITLE
fix(templates): remove extra alt text from the Firefox logo

### DIFF
--- a/templates/new_sync_device.html
+++ b/templates/new_sync_device.html
@@ -14,7 +14,7 @@
             <!--Logo-->
             <tr>
               <td align="center" id="firefox-logo" style="padding: 20px 0;">
-                <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="Firefox" style="-ms-interpolation-mode: bicubic;" />
+                <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
               </td>
             </tr>
 

--- a/templates/password_changed.html
+++ b/templates/password_changed.html
@@ -14,7 +14,7 @@
             <!--Logo-->
             <tr>
               <td align="center" id="firefox-logo" style="padding: 20px 0;">
-                <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="Firefox" style="-ms-interpolation-mode: bicubic;" />
+                <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
               </td>
             </tr>
 

--- a/templates/password_reset.html
+++ b/templates/password_reset.html
@@ -14,7 +14,7 @@
             <!--Logo-->
             <tr>
               <td align="center" id="firefox-logo" style="padding: 20px 0;">
-                <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="Firefox" style="-ms-interpolation-mode: bicubic;" />
+                <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
               </td>
             </tr>
 

--- a/templates/post_verify.html
+++ b/templates/post_verify.html
@@ -14,7 +14,7 @@
             <!--Logo-->
             <tr>
               <td align="center" id="firefox-logo" style="padding: 20px 0;">
-                <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="Firefox" style="-ms-interpolation-mode: bicubic;" />
+                <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
               </td>
             </tr>
 

--- a/templates/reset.html
+++ b/templates/reset.html
@@ -14,7 +14,7 @@
             <!--Logo-->
             <tr>
               <td align="center" id="firefox-logo" style="padding: 20px 0;">
-                <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="Firefox" style="-ms-interpolation-mode: bicubic;" />
+                <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
               </td>
             </tr>
 

--- a/templates/unlock.html
+++ b/templates/unlock.html
@@ -14,7 +14,7 @@
             <!--Logo-->
             <tr>
               <td align="center" id="firefox-logo" style="padding: 20px 0;">
-                <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="Firefox" style="-ms-interpolation-mode: bicubic;" />
+                <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
               </td>
             </tr>
 

--- a/templates/verification_reminder.html
+++ b/templates/verification_reminder.html
@@ -14,7 +14,7 @@
             <!--Logo-->
             <tr>
               <td align="center" id="firefox-logo" style="padding: 20px 0;">
-                <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="Firefox" style="-ms-interpolation-mode: bicubic;" />
+                <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
               </td>
             </tr>
 

--- a/templates/verify.html
+++ b/templates/verify.html
@@ -14,7 +14,7 @@
             <!--Logo-->
             <tr>
               <td align="center" id="firefox-logo" style="padding: 20px 0;">
-                <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="Firefox" style="-ms-interpolation-mode: bicubic;" />
+                <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
               </td>
             </tr>
 


### PR DESCRIPTION
Fixes #86