### PR TITLE
fix(l10n): remove html attributes from string

### DIFF
--- a/mailer.js
+++ b/mailer.js
@@ -54,6 +54,12 @@ module.exports = function (log) {
     this.mailer.close()
   }
 
+  Mailer.prototype._supportLinkAttributes = function () {
+    // Not very nice to have presentation code in here, but this is to help l10n
+    // contributors not deal with extraneous noise in strings.
+    return 'href="' + this.supportUrl + '" style="color: #0095dd; text-decoration: none;"'
+  }
+
   Mailer.prototype.send = function (message) {
     log.trace({ op: 'mailer.' + message.template, email: message.email, uid: message.uid })
 
@@ -123,7 +129,8 @@ module.exports = function (log) {
         email: message.email,
         link: link,
         oneClickLink: oneClickLink,
-        supportUrl: this.supportUrl
+        supportUrl: this.supportUrl,
+        supportLinkAttributes: this._supportLinkAttributes()
       },
       uid: message.uid
     })
@@ -154,7 +161,8 @@ module.exports = function (log) {
         code: message.code,
         email: message.email,
         link: link,
-        supportUrl: this.supportUrl
+        supportUrl: this.supportUrl,
+        supportLinkAttributes: this._supportLinkAttributes()
       },
       uid: message.uid
     })
@@ -185,7 +193,8 @@ module.exports = function (log) {
       templateValues: {
         email: message.email,
         link: link,
-        supportUrl: this.supportUrl
+        supportUrl: this.supportUrl,
+        supportLinkAttributes: this._supportLinkAttributes()
       },
       uid: message.uid
     })
@@ -208,7 +217,8 @@ module.exports = function (log) {
       template: 'passwordChangedEmail',
       templateValues: {
         resetLink: link,
-        supportUrl: this.supportUrl
+        supportUrl: this.supportUrl,
+        supportLinkAttributes: this._supportLinkAttributes()
       },
       uid: message.uid
     })
@@ -228,7 +238,8 @@ module.exports = function (log) {
       template: 'passwordResetEmail',
       templateValues: {
         resetLink: link,
-        supportUrl: this.supportUrl
+        supportUrl: this.supportUrl,
+        supportLinkAttributes: this._supportLinkAttributes()
       },
       uid: message.uid
     })
@@ -248,7 +259,8 @@ module.exports = function (log) {
       template: 'newSyncDeviceEmail',
       templateValues: {
         resetLink: link,
-        supportUrl: this.supportUrl
+        supportUrl: this.supportUrl,
+        supportLinkAttributes: this._supportLinkAttributes()
       },
       uid: message.uid
     })
@@ -271,7 +283,8 @@ module.exports = function (log) {
         link: link,
         androidUrl: this.androidUrl,
         iosUrl: this.iosUrl,
-        supportUrl: this.supportUrl
+        supportUrl: this.supportUrl,
+        supportLinkAttributes: this._supportLinkAttributes()
       },
       uid: message.uid
     })
@@ -307,7 +320,8 @@ module.exports = function (log) {
         email: message.email,
         link: link,
         oneClickLink: oneClickLink,
-        supportUrl: this.supportUrl
+        supportUrl: this.supportUrl,
+        supportLinkAttributes: this._supportLinkAttributes()
       },
       uid: message.uid
     })

--- a/partials/base/base_text_only.html
+++ b/partials/base/base_text_only.html
@@ -13,7 +13,7 @@
   <td border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
     <br/>
     <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap:break-word">
-      <% block text_secondary %>{{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a href='%(supportUrl)s' style='color: #0095dd; text-decoration: none;'>Mozilla Support</a>"}}}<% endblock %>
+      <% block text_secondary %>{{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a %(supportLinkAttributes)s>Mozilla Support</a>"}}}<% endblock %>
     </p>
   </td>
 </tr>

--- a/partials/post_verify.html
+++ b/partials/post_verify.html
@@ -35,7 +35,7 @@
   <td border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
     <br/>
     <p width="310" class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 24px 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap: break-word">{{t "Alternatively:"}}<a href="{{{link}}}" style="color: #0095dd; text-decoration: none; width: 310px !important; display:block;"><br/>{{{link}}}</a></p>
-    <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap:break-word">{{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a href='%(supportUrl)s' style='color: #0095dd; text-decoration: none;'>Mozilla Support</a>"}}}</p>
+    <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap:break-word">{{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a %(supportLinkAttributes)s>Mozilla Support</a>"}}}</p>
   </td>
 </tr>
 <% endblock %>

--- a/partials/reset.html
+++ b/partials/reset.html
@@ -35,7 +35,7 @@
   <td border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
     <br/>
     <p width="310" class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 24px 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap: break-word; word-break: break-all">{{t "Alternatively:"}}<a href="{{{link}}}" style="color: #0095dd; text-decoration: none; width: 310px !important; display:block;"><br/><font style="word-break:break-all;">{{{link}}}</font></a></p>
-    <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap:break-word">{{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a href='%(supportUrl)s' style='color: #0095dd; text-decoration: none;'>Mozilla Support</a>"}}}</p>
+    <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap:break-word">{{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a %(supportLinkAttributes)s>Mozilla Support</a>"}}}</p>
   </td>
 </tr>
 <% endblock %>

--- a/partials/unlock.html
+++ b/partials/unlock.html
@@ -35,7 +35,7 @@
   <td border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
     <br/>
     <p width="310" class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 24px 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap: break-word">{{t "Alternatively:"}}<a href="{{{link}}}" style="color: #0095dd; text-decoration: none; width: 310px !important; display:block;"><br/>{{{link}}}</a></p>
-    <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap:break-word">{{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a href='%(supportUrl)s' style='color: #0095dd; text-decoration: none;'>Mozilla Support</a>"}}}</p>
+    <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap:break-word">{{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a %(supportLinkAttributes)s>Mozilla Support</a>"}}}</p>
   </td>
 </tr>
 <% endblock %>

--- a/partials/verification_reminder.html
+++ b/partials/verification_reminder.html
@@ -35,7 +35,7 @@
   <td border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
     <br/>
     <p width="310" class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 24px 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap: break-word">{{t "Alternatively:"}}<a href="{{{link}}}" style="color: #0095dd; text-decoration: none; width: 310px !important; display:block;"><br/>{{{link}}}</a></p>
-    <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap:break-word">{{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a href='%(supportUrl)s' style='color: #0095dd; text-decoration: none;'>Mozilla Support</a>"}}}</p>
+    <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap:break-word">{{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a %(supportLinkAttributes)s>Mozilla Support</a>"}}}</p>
   </td>
 </tr>
 <% endblock %>

--- a/partials/verify.html
+++ b/partials/verify.html
@@ -35,7 +35,7 @@
   <td border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
     <br/>
     <p width="310" class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 24px 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap: break-word; word-break: break-all">{{t "Alternatively:"}}<a href="{{{link}}}" style="color: #0095dd; text-decoration: none; width: 310px !important; display:block;"><br/><font style="word-break:break-all;">{{{link}}}</font></a></p>
-    <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap:break-word">{{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a href='%(supportUrl)s' style='color: #0095dd; text-decoration: none;'>Mozilla Support</a>"}}}</p>
+    <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap:break-word">{{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a %(supportLinkAttributes)s>Mozilla Support</a>"}}}</p>
   </td>
 </tr>
 <% endblock %>

--- a/templates/new_sync_device.html
+++ b/templates/new_sync_device.html
@@ -27,7 +27,7 @@
   <td border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
     <br/>
     <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap:break-word">
-      {{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a href='%(supportUrl)s' style='color: #0095dd; text-decoration: none;'>Mozilla Support</a>"}}}
+      {{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a %(supportLinkAttributes)s>Mozilla Support</a>"}}}
     </p>
   </td>
 </tr>

--- a/templates/password_changed.html
+++ b/templates/password_changed.html
@@ -27,7 +27,7 @@
   <td border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
     <br/>
     <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap:break-word">
-      {{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a href='%(supportUrl)s' style='color: #0095dd; text-decoration: none;'>Mozilla Support</a>"}}}
+      {{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a %(supportLinkAttributes)s>Mozilla Support</a>"}}}
     </p>
   </td>
 </tr>

--- a/templates/password_reset.html
+++ b/templates/password_reset.html
@@ -27,7 +27,7 @@
   <td border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
     <br/>
     <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap:break-word">
-      {{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a href='%(supportUrl)s' style='color: #0095dd; text-decoration: none;'>Mozilla Support</a>"}}}
+      {{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a %(supportLinkAttributes)s>Mozilla Support</a>"}}}
     </p>
   </td>
 </tr>

--- a/templates/post_verify.html
+++ b/templates/post_verify.html
@@ -49,7 +49,7 @@
   <td border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
     <br/>
     <p width="310" class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 24px 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap: break-word">{{t "Alternatively:"}}<a href="{{{link}}}" style="color: #0095dd; text-decoration: none; width: 310px !important; display:block;"><br/>{{{link}}}</a></p>
-    <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap:break-word">{{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a href='%(supportUrl)s' style='color: #0095dd; text-decoration: none;'>Mozilla Support</a>"}}}</p>
+    <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap:break-word">{{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a %(supportLinkAttributes)s>Mozilla Support</a>"}}}</p>
   </td>
 </tr>
 

--- a/templates/reset.html
+++ b/templates/reset.html
@@ -49,7 +49,7 @@
   <td border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
     <br/>
     <p width="310" class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 24px 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap: break-word; word-break: break-all">{{t "Alternatively:"}}<a href="{{{link}}}" style="color: #0095dd; text-decoration: none; width: 310px !important; display:block;"><br/><font style="word-break:break-all;">{{{link}}}</font></a></p>
-    <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap:break-word">{{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a href='%(supportUrl)s' style='color: #0095dd; text-decoration: none;'>Mozilla Support</a>"}}}</p>
+    <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap:break-word">{{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a %(supportLinkAttributes)s>Mozilla Support</a>"}}}</p>
   </td>
 </tr>
 

--- a/templates/unlock.html
+++ b/templates/unlock.html
@@ -49,7 +49,7 @@
   <td border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
     <br/>
     <p width="310" class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 24px 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap: break-word">{{t "Alternatively:"}}<a href="{{{link}}}" style="color: #0095dd; text-decoration: none; width: 310px !important; display:block;"><br/>{{{link}}}</a></p>
-    <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap:break-word">{{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a href='%(supportUrl)s' style='color: #0095dd; text-decoration: none;'>Mozilla Support</a>"}}}</p>
+    <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap:break-word">{{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a %(supportLinkAttributes)s>Mozilla Support</a>"}}}</p>
   </td>
 </tr>
 

--- a/templates/verification_reminder.html
+++ b/templates/verification_reminder.html
@@ -49,7 +49,7 @@
   <td border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
     <br/>
     <p width="310" class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 24px 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap: break-word">{{t "Alternatively:"}}<a href="{{{link}}}" style="color: #0095dd; text-decoration: none; width: 310px !important; display:block;"><br/>{{{link}}}</a></p>
-    <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap:break-word">{{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a href='%(supportUrl)s' style='color: #0095dd; text-decoration: none;'>Mozilla Support</a>"}}}</p>
+    <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap:break-word">{{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a %(supportLinkAttributes)s>Mozilla Support</a>"}}}</p>
   </td>
 </tr>
 

--- a/templates/verify.html
+++ b/templates/verify.html
@@ -49,7 +49,7 @@
   <td border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
     <br/>
     <p width="310" class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 24px 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap: break-word; word-break: break-all">{{t "Alternatively:"}}<a href="{{{link}}}" style="color: #0095dd; text-decoration: none; width: 310px !important; display:block;"><br/><font style="word-break:break-all;">{{{link}}}</font></a></p>
-    <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap:break-word">{{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a href='%(supportUrl)s' style='color: #0095dd; text-decoration: none;'>Mozilla Support</a>"}}}</p>
+    <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap:break-word">{{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a %(supportLinkAttributes)s>Mozilla Support</a>"}}}</p>
   </td>
 </tr>
 

--- a/test/local/mailer_tests.js
+++ b/test/local/mailer_tests.js
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+var P = require('bluebird')
+var test = require('tap').test
+
+var nullLog = {
+  trace: function () {},
+  info: function () {}
+}
+
+var config = require('../../config')
+var Mailer = require('../../mailer')(nullLog)
+
+var messageTypes = [
+  'verifyEmail',
+  'recoveryEmail',
+  'unlockEmail',
+  'passwordChangedEmail',
+  'passwordResetEmail',
+  'newSyncDeviceEmail',
+  'postVerifyEmail',
+  'verificationReminderEmail'
+]
+
+P.all(
+  [
+    require('../../translator')(['en'], 'en'),
+    require('../../templates')()
+  ]
+)
+.spread(
+  function (translator, templates) {
+    messageTypes.forEach(
+      function (type) {
+        var mailer = new Mailer(translator, templates, config.mail)
+
+        var message = {
+          email: 'a@b.com',
+          uid: 'uid',
+          code: 'abc123',
+          service: 'service',
+        }
+
+        var supportHtmlLink = new RegExp('<a href="' + config.mail.supportUrl + '" style="color: #0095dd; text-decoration: none;">Mozilla Support</a>')
+        var supportTextLink = config.mail.supportUrl
+
+        test(
+          'test support link is in email template output for ' + type,
+          function (t) {
+            mailer.mailer.sendMail = function (emailConfig) {
+              t.equal(!! emailConfig.html.match(supportHtmlLink), true)
+              t.equal(!! emailConfig.text.match(supportTextLink), true)
+              t.end()
+            }
+            mailer[type](message)
+          }
+        )
+      }
+    )
+  }
+)
+


### PR DESCRIPTION
Fixes #74 
@dannycoates r?

When merging the next batch of extracted strings, we'll need to convert/regex-foo the old stings into this new format so we don't lose any translations.