### PR TITLE
fix(l10n): Convert const to var to fix l10n-extract Grunt task

### DIFF
--- a/config.js
+++ b/config.js
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const fs = require('fs')
-const path = require('path')
+var fs = require('fs')
+var path = require('path')
 
-const convict = require('convict')
+var convict = require('convict')
 
-const conf = convict({
+var conf = convict({
   env: {
     doc: 'The current node.js environment',
     default: 'prod',


### PR DESCRIPTION
Not sure why the l10n-extract task chokes on `const` keyword, but the world is a funny place.

```sh
➜  fxa-auth-mailer git:(issue-114) $ grunt l10n-extract
Running "l10n-extract" task

Done, without errors.


$ node --version && npm --version
v0.10.35
2.14.2
```

Fixes #114 