### PR TITLE
chore(dependencies): upgrade mozlog to 2.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "handlebars": "1.3.0",
     "i18n-abide": "0.0.23",
     "jed": "0.5.4",
-    "mozlog": "2.0.2",
+    "mozlog": "2.0.3",
     "nodemailer": "0.7.1",
     "po2json": "0.4.1",
     "poolee": "1.0.0",


### PR DESCRIPTION
Picks up this fix for exception logging - https://github.com/mozilla/mozlog/commit/e11def164c2a8cf2578930227815bea01c90b799