### PR TITLE
fix(mailer): Several mailer fixes

### DIFF
--- a/mailer.js
+++ b/mailer.js
@@ -251,7 +251,7 @@ module.exports = function (log) {
         code: message.code,
         email: message.email,
         link: link,
-        signInUrl: this.signInUrl,
+        signInUrl: this.createSignInLink(message.email),
         supportUrl: this.supportUrl,
         supportLinkAttributes: this._supportLinkAttributes()
       },
@@ -305,7 +305,6 @@ module.exports = function (log) {
       templateValues: {
         resetLink: link,
         resetLinkAttributes: this._passwordResetLinkAttributes(message.email),
-        signInUrl: this.signInUrl,
         supportLinkAttributes: this._supportLinkAttributes(),
         supportUrl: this.supportUrl
       },
@@ -494,6 +493,12 @@ module.exports = function (log) {
     var queryParams = { email: email }
 
     return this.initiatePasswordChangeUrl + '?' + qs.stringify(queryParams)
+  }
+
+  Mailer.prototype.createSignInLink = function (email) {
+    var queryParams = { email: email }
+
+    return this.signInUrl + '?' + qs.stringify(queryParams)
   }
 
   return Mailer

--- a/mailer.js
+++ b/mailer.js
@@ -388,6 +388,8 @@ module.exports = function (log) {
     // details at github.com/mozilla/fxa-auth-mailer/issues/110
     var postVerifyUtmParams = '?utm_source=email&utm_medium=email&utm_campaign=fx-account-verified'
     var link = this.syncUrl + postVerifyUtmParams
+    var anrdoidLink = this.androidUrl + postVerifyUtmParams
+    var iosLink = this.iosUrl + postVerifyUtmParams
 
     return this.send({
       acceptLanguage: message.acceptLanguage,
@@ -399,8 +401,10 @@ module.exports = function (log) {
       template: 'postVerifyEmail',
       templateValues: {
         link: link,
-        androidUrl: this.androidUrl + postVerifyUtmParams,
-        iosUrl: this.iosUrl + postVerifyUtmParams,
+        androidUrl: anrdoidLink,
+        androidLinkAttributes: linkAttributes(anrdoidLink),
+        iosUrl: iosLink,
+        iosLinkAttributes: linkAttributes(iosLink),
         supportUrl: this.supportUrl,
         supportLinkAttributes: this._supportLinkAttributes()
       },

--- a/partials/password_changed.html
+++ b/partials/password_changed.html
@@ -1,4 +1,21 @@
-<% extends "partials/base/base_text_only.html" %>
+<% extends "partials/base/base.html" %>
 
-<% block heading %>{{t "Password changed successfully"}}<% endblock %>
-<% block text_primary %>{{t "Your Firefox Account password has been successfully changed." }}<% endblock %>
+<% block content %>
+<!--Header Area-->
+<tr style="page-break-before: always">
+  <td valign="top">
+    <h1 style="font-family: sans-serif; font-weight: normal; margin: 0 0 24px 0; text-align: center;">{{t "Password changed successfully"}}</h1>
+    <p class="primary" style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 12px 0; text-align: center;">{{t "Your Firefox Account password has been successfully changed." }}</p>
+  </td>
+</tr>
+
+<!--Button Area-->
+<tr style="page-break-before: always">
+  <td border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
+    <br/>
+    <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 12px 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap:break-word">
+      {{{t "This is an automated email; if you did not authorize this action, then <a %(resetLinkAttributes)s>please reset your password</a>." }}} {{{t "For more information, please visit <a %(supportLinkAttributes)s>Mozilla Support</a>."}}}
+    </p>
+  </td>
+</tr>
+<% endblock %>

--- a/partials/password_reset.html
+++ b/partials/password_reset.html
@@ -5,7 +5,7 @@
 <tr style="page-break-before: always">
     <td valign="top">
         <h3 style="font-family: sans-serif; font-weight: normal; margin: 0 0 24px 0; text-align: center;">{{t "Your password has been reset"}}</h3>
-        <p class="primary" style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 12px 0; text-align: center;">{{{t "Your Firefox Account password has changed. If you did not change it, please <a href='%(resetLink)s'>reset your password</a> now." }}}</p>
+        <p class="primary" style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 12px 0; text-align: center;">{{{t "Your Firefox Account password has changed. If you did not change it, please <a %(resetLinkAttributes)s>reset your password</a> now." }}}</p>
     </td>
 </tr>
 

--- a/partials/post_verify.html
+++ b/partials/post_verify.html
@@ -5,7 +5,7 @@
 <tr style="page-break-before: always">
   <td valign="top">
     <h1 style="font-family: sans-serif; font-weight: normal; margin: 0 0 24px 0; text-align: center;">{{t "Account verified!" }}</h1>
-    <p class="primary" style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 24px 0; text-align: center;">{{{t "You successfully connected your first device to your Firefox Account. Now you can sign in to Sync from your other devices, including Firefox for <a href='%(androidUrl)s'>Android</a> and <a href='%(iosUrl)s'>iOS</a>." }}}</p>
+    <p class="primary" style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 24px 0; text-align: center;">{{{t "You successfully connected your first device to your Firefox Account. Now you can sign in to Sync from your other devices, including Firefox for <a %(androidLinkAttributes)s>Android</a> and <a %(iosLinkAttributes)s>iOS</a>." }}}</p>
   </td>
 </tr>
 

--- a/templates/password_changed.html
+++ b/templates/password_changed.html
@@ -24,11 +24,12 @@
   </td>
 </tr>
 
+<!--Button Area-->
 <tr style="page-break-before: always">
   <td border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
     <br/>
     <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 12px 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap:break-word">
-      {{{t "This is an automated email; if you did not authorize this action, then <a %(passwordChangeLinkAttributes)s>please change your password.</a>" }}} {{{t "For more information, please visit <a %(supportLinkAttributes)s>Mozilla Support</a>."}}}
+      {{{t "This is an automated email; if you did not authorize this action, then <a %(resetLinkAttributes)s>please reset your password</a>." }}} {{{t "For more information, please visit <a %(supportLinkAttributes)s>Mozilla Support</a>."}}}
     </p>
   </td>
 </tr>

--- a/templates/password_changed.txt
+++ b/templates/password_changed.txt
@@ -1,7 +1,7 @@
 {{t "Password changed successfully" }}
 {{t "Your Firefox Account password has been successfully changed." }}
 
-{{t "This is an automated email; if you didn’t change the password to your Firefox Account, you should reset it immediately at %(resetLink)s." }}
+{{{t "This is an automated email; if you didn’t change the password to your Firefox Account, you should reset it immediately at %(resetLink)s." }}}
 {{t "For more information, please visit %(supportUrl)s" }}
 
 Mozilla. 331 E Evelyn Ave, Mountain View, CA 94041

--- a/templates/password_reset.html
+++ b/templates/password_reset.html
@@ -20,7 +20,7 @@
 <tr style="page-break-before: always">
     <td valign="top">
         <h3 style="font-family: sans-serif; font-weight: normal; margin: 0 0 24px 0; text-align: center;">{{t "Your password has been reset"}}</h3>
-        <p class="primary" style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 12px 0; text-align: center;">{{{t "Your Firefox Account password has changed. If you did not change it, please <a href='%(resetLink)s'>reset your password</a> now." }}}</p>
+        <p class="primary" style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 12px 0; text-align: center;">{{{t "Your Firefox Account password has changed. If you did not change it, please <a %(resetLinkAttributes)s>reset your password</a> now." }}}</p>
     </td>
 </tr>
 

--- a/templates/password_reset.txt
+++ b/templates/password_reset.txt
@@ -1,9 +1,7 @@
 {{t "Password reset successfully" }}
 {{t "Your Firefox Account password has been successfully reset." }}
 
-{{{t "Your Firefox Account password has changed. If you did not change it, please <a href='%(resetLink)s'>reset your password</a> now." }}}
-
-{{t "This is an automated email; if you didn’t reset the password to your Firefox Account, you should reset it immediately at %(resetLink)s." }}
+{{{t "This is an automated email; if you didn’t reset the password to your Firefox Account, you should reset it immediately at %(resetLink)s." }}}
 {{t "For more information, please visit %(supportUrl)s" }}
 
 Mozilla. 331 E Evelyn Ave, Mountain View, CA 94041

--- a/templates/post_verify.html
+++ b/templates/post_verify.html
@@ -20,7 +20,7 @@
 <tr style="page-break-before: always">
   <td valign="top">
     <h1 style="font-family: sans-serif; font-weight: normal; margin: 0 0 24px 0; text-align: center;">{{t "Account verified!" }}</h1>
-    <p class="primary" style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 24px 0; text-align: center;">{{{t "You successfully connected your first device to your Firefox Account. Now you can sign in to Sync from your other devices, including Firefox for <a href='%(androidUrl)s'>Android</a> and <a href='%(iosUrl)s'>iOS</a>." }}}</p>
+    <p class="primary" style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 24px 0; text-align: center;">{{{t "You successfully connected your first device to your Firefox Account. Now you can sign in to Sync from your other devices, including Firefox for <a %(androidLinkAttributes)s>Android</a> and <a %(iosLinkAttributes)s>iOS</a>." }}}</p>
   </td>
 </tr>
 

--- a/templates/reset.txt
+++ b/templates/reset.txt
@@ -1,7 +1,7 @@
 {{t "Forgot your password?"}}
 
 {{{t "Click the button within the next hour to set a new password for your Firefox Account." }}}
-{{t "Remember password? Sign in."}}
+{{t "Remember password? Sign in."}} {{{ signInUrl }}}
 {{t "Reset password"}} {{{link}}}
 
 {{t "This is an automated email; if you received it in error, no action is required."}} {{t "For more information, please visit %(supportUrl)s"}}

--- a/test/local/mailer_tests.js
+++ b/test/local/mailer_tests.js
@@ -27,7 +27,7 @@ var messageTypes = [
   'verifyLoginEmail'
 ]
 
-var typesWithSupportLinks = [
+var typesContainSupportLinks = [
   'newDeviceLoginEmail',
   'passwordChangedEmail',
   'passwordResetEmail',
@@ -52,6 +52,14 @@ var typesContainPasswordChangeLinks = [
 
 var typesContainSignInLinks = [
   'recoveryEmail'
+]
+
+var typesContainAndroidStoreLinks = [
+  'postVerifyEmail'
+]
+
+var typesContainIOSStoreLinks = [
+  'postVerifyEmail'
 ]
 
 function includes(haystack, needle) {
@@ -82,7 +90,7 @@ P.all(
         var supportHtmlLink = new RegExp('<a href="' + config.get('mail').supportUrl + '" style="color: #0095dd; text-decoration: none; font-family: sans-serif;">Mozilla Support</a>')
         var supportTextLink = config.get('mail').supportUrl
 
-        if (includes(typesWithSupportLinks, type)) {
+        if (includes(typesContainSupportLinks, type)) {
           test(
             'test support link is in email template output for ' + type,
             function (t) {
@@ -120,6 +128,38 @@ P.all(
               mailer.mailer.sendMail = function (emailConfig) {
                 t.ok(includes(emailConfig.html, passwordChangeLink))
                 t.ok(includes(emailConfig.text, passwordChangeLink))
+                t.end()
+              }
+              mailer[type](message)
+            }
+          )
+        }
+
+        if (includes(typesContainAndroidStoreLinks, type)) {
+          var androidStoreLink = mailer.androidUrl
+
+          test(
+            'Android store link is in email template output for ' + type,
+            function (t) {
+              mailer.mailer.sendMail = function (emailConfig) {
+                t.ok(includes(emailConfig.html, androidStoreLink))
+                // only the html email contains links to the store
+                t.end()
+              }
+              mailer[type](message)
+            }
+          )
+        }
+
+        if (includes(typesContainIOSStoreLinks, type)) {
+          var iosStoreLink = mailer.iosUrl
+
+          test(
+            'IOS store link is in email template output for ' + type,
+            function (t) {
+              mailer.mailer.sendMail = function (emailConfig) {
+                t.ok(includes(emailConfig.html, iosStoreLink))
+                // only the html email contains links to the store
                 t.end()
               }
               mailer[type](message)

--- a/test/local/mailer_tests.js
+++ b/test/local/mailer_tests.js
@@ -50,6 +50,10 @@ var typesContainPasswordChangeLinks = [
   'verifyLoginEmail'
 ]
 
+var typesContainSignInLinks = [
+  'recoveryEmail'
+]
+
 function includes(haystack, needle) {
   return (haystack.indexOf(needle) > -1)
 }
@@ -116,6 +120,21 @@ P.all(
               mailer.mailer.sendMail = function (emailConfig) {
                 t.ok(includes(emailConfig.html, passwordChangeLink))
                 t.ok(includes(emailConfig.text, passwordChangeLink))
+                t.end()
+              }
+              mailer[type](message)
+            }
+          )
+        }
+
+        if (includes(typesContainSignInLinks, type)) {
+          var signInLink = mailer.createSignInLink(message.email)
+          test(
+            'sign in link is in email template output for ' + type,
+            function (t) {
+              mailer.mailer.sendMail = function (emailConfig) {
+                t.ok(includes(emailConfig.html, signInLink))
+                t.ok(includes(emailConfig.text, signInLink))
                 t.end()
               }
               mailer[type](message)

--- a/test/local/mailer_tests.js
+++ b/test/local/mailer_tests.js
@@ -38,7 +38,9 @@ var typesWithSupportLinks = [
   'verifyEmail'
 ]
 
-var typesContainConfirmlessPasswordResetLinks = [
+var typesContainPasswordResetLinks = [
+  'passwordChangedEmail',
+  'passwordResetEmail',
   'passwordResetRequiredEmail',
   'suspiciousLocationEmail'
 ]
@@ -90,15 +92,15 @@ P.all(
           )
         }
 
-        if (includes(typesContainConfirmlessPasswordResetLinks, type)) {
-          var confirmlessResetPasswordLink = mailer.createPasswordResetLink(message.email, { reset_password_confirm: false })
+        if (includes(typesContainPasswordResetLinks, type)) {
+          var resetPasswordLink = mailer.createPasswordResetLink(message.email)
 
           test(
             'reset password link is in email template output for ' + type,
             function (t) {
               mailer.mailer.sendMail = function (emailConfig) {
-                t.ok(includes(emailConfig.html, confirmlessResetPasswordLink))
-                t.ok(includes(emailConfig.text, confirmlessResetPasswordLink))
+                t.ok(includes(emailConfig.html, resetPasswordLink))
+                t.ok(includes(emailConfig.text, resetPasswordLink))
                 t.end()
               }
               mailer[type](message)


### PR DESCRIPTION
* Password changed template shows "reset your password" link. "change your password" used to be displayed. If an attacker changed the user's password, the user would not know the new password to change it.
* Fix the "reset password" link color in the "Your password has been reset" email.
* All password reset links auto-submit the password reset form.
* The "Change your password" link in the "New sign in to Firefox" email contains the users email address.

fixes #151
fixes #153
fixes #154
fixes #155
fixes #157