### PR TITLE
chore(mozlog): update from mozlog@2.0.3 to 2.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "handlebars": "1.3.0",
     "i18n-abide": "0.0.23",
     "jed": "0.5.4",
-    "mozlog": "2.0.3",
+    "mozlog": "2.0.5",
     "nodemailer": "0.7.1",
     "po2json": "0.4.1",
     "poolee": "1.0.0",


### PR DESCRIPTION
r? - @vladikoff 

Picks up a couple of error logging fixes.