### PR TITLE
feat(metrics): include type of reminder in the email query

### DIFF
--- a/mailer.js
+++ b/mailer.js
@@ -466,7 +466,8 @@ module.exports = function (log) {
 
     var query = {
       uid: message.uid,
-      code: message.code
+      code: message.code,
+      reminder: message.type
     }
 
     var link = this.verificationUrl + '?' + qs.stringify(query)

--- a/test/local/mailer_tests.js
+++ b/test/local/mailer_tests.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+var extend = require('util')._extend
+
 var P = require('bluebird')
 var test = require('tap').test
 
@@ -247,6 +249,22 @@ P.all(
                 t.end()
               }
               mailer[type](message)
+            }
+          )
+        } else if (type === 'verificationReminderEmail') {
+          var reminderMessage = extend(message, {
+            type: 'customType'
+          })
+
+          test(
+            'custom reminder types are supported in output for ' + type,
+            function (t) {
+              mailer.mailer.sendMail = function (emailConfig) {
+                t.ok(includes(emailConfig.html, 'reminder=customType'))
+                t.ok(includes(emailConfig.text, 'reminder=customType'))
+                t.end()
+              }
+              mailer[type](reminderMessage)
             }
           )
         }


### PR DESCRIPTION
@rfk r?

This will allow us to track verification flow via reminders on the auth-server


ref https://github.com/mozilla/fxa/issues/138