### PR TITLE
fix(bind): should by default bind to localhost

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -83,8 +83,9 @@ P.all(
 
     api.listen(
       config.get('port'),
+      config.get('host'),
       function () {
-        log.info('listening', { port: config.get('port') })
+        log.info('listening', { port: config.get('port'), host: config.get('host') })
       }
     )
   }

--- a/config.js
+++ b/config.js
@@ -19,6 +19,11 @@ var conf = convict({
     format: 'port',
     default: 10136
   },
+  host: {
+    env: 'MAILER_HOST',
+    format: 'ipaddress',
+    default: '127.0.0.1'
+  },
   db: {
     backend: {
       default: 'httpdb',


### PR DESCRIPTION
The default binding should be localhost; not a public endpoint, right? 

r? - @vladikoff 