### PR TITLE
fix(mailer): Slow down the verification reminder emails in dev.

### DIFF
--- a/config/dev.json
+++ b/config/dev.json
@@ -4,8 +4,8 @@
     "fmt": "pretty"
   },
   "verificationReminders": {
-    "reminderTimeFirst": 1000,
-    "reminderTimeSecond": 5000,
+    "reminderTimeFirst": 10000,
+    "reminderTimeSecond": 15000,
     "pollTime": 5000
   }
 }


### PR DESCRIPTION
This fixes the content-server functional tests for unverified accounts. The
verification reminder emails arrived before sign in w/ an unverified account
verification emails.

fixes mozilla/fxa-content-server#3929

@vladikoff - r? ~~Can you hold off on merging, I want to make sure this really does what it says it does.~~