### PR TITLE
fix(mailer): Fix the title size in the password reset related templates.

### DIFF
--- a/partials/password_reset.html
+++ b/partials/password_reset.html
@@ -4,7 +4,7 @@
 <!--Header Area-->
 <tr style="page-break-before: always">
     <td valign="top">
-        <h3 style="font-family: sans-serif; font-weight: normal; margin: 0 0 24px 0; text-align: center;">{{t "Your password has been reset"}}</h3>
+        <h1 style="font-family: sans-serif; font-weight: normal; margin: 0 0 24px 0; text-align: center;">{{t "Your password has been reset"}}</h1>
         <p class="primary" style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 12px 0; text-align: center;">{{{t "Your Firefox Account password has changed. If you did not change it, please <a %(resetLinkAttributes)s>reset your password</a> now." }}}</p>
     </td>
 </tr>

--- a/partials/recovery.html
+++ b/partials/recovery.html
@@ -4,7 +4,7 @@
 <!--Header Area-->
 <tr style="page-break-before: always">
   <td valign="top">
-    <h3 style="font-family: sans-serif; font-weight: normal; margin: 0 0 24px 0; text-align: center;">{{t "Forgot your password?"}}</h3>
+    <h1 style="font-family: sans-serif; font-weight: normal; margin: 0 0 24px 0; text-align: center;">{{t "Forgot your password?"}}</h1>
     <p class="primary" style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 24px 0; text-align: center;">{{{t "Click the button within the next hour to set a new password for your Firefox Account." }}}</p>
   </td>
 </tr>

--- a/templates/password_reset.html
+++ b/templates/password_reset.html
@@ -19,7 +19,7 @@
 <!--Header Area-->
 <tr style="page-break-before: always">
     <td valign="top">
-        <h3 style="font-family: sans-serif; font-weight: normal; margin: 0 0 24px 0; text-align: center;">{{t "Your password has been reset"}}</h3>
+        <h1 style="font-family: sans-serif; font-weight: normal; margin: 0 0 24px 0; text-align: center;">{{t "Your password has been reset"}}</h1>
         <p class="primary" style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 12px 0; text-align: center;">{{{t "Your Firefox Account password has changed. If you did not change it, please <a %(resetLinkAttributes)s>reset your password</a> now." }}}</p>
     </td>
 </tr>

--- a/templates/recovery.html
+++ b/templates/recovery.html
@@ -19,7 +19,7 @@
 <!--Header Area-->
 <tr style="page-break-before: always">
   <td valign="top">
-    <h3 style="font-family: sans-serif; font-weight: normal; margin: 0 0 24px 0; text-align: center;">{{t "Forgot your password?"}}</h3>
+    <h1 style="font-family: sans-serif; font-weight: normal; margin: 0 0 24px 0; text-align: center;">{{t "Forgot your password?"}}</h1>
     <p class="primary" style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 24px 0; text-align: center;">{{{t "Click the button within the next hour to set a new password for your Firefox Account." }}}</p>
   </td>
 </tr>


### PR DESCRIPTION
Change both "password_reset" and "recovery" to use `h1` instead of `h3`

fixes #217 


<img width="359" alt="screen shot 2016-09-29 at 21 54 49" src="https://cloud.githubusercontent.com/assets/848085/18972095/a915490e-868f-11e6-91be-ef4c1fd6ca45.png">

<img width="357" alt="screen shot 2016-09-29 at 21 54 53" src="https://cloud.githubusercontent.com/assets/848085/18972096/aa3a8272-868f-11e6-891e-1beb3ec4efd0.png">

@ryanfeeley - r?