### PR TITLE
feat(mailer): Remove the `Alternatively` link from all emails.

### DIFF
--- a/mailer.js
+++ b/mailer.js
@@ -268,7 +268,6 @@ module.exports = function (log) {
       subject: gettext('Verify your Firefox Account'),
       template: templateName,
       templateValues: {
-        alternativeLink: links.alternativeLink,
         email: message.email,
         link: links.link,
         oneClickLink: links.oneClickLink,
@@ -344,7 +343,6 @@ module.exports = function (log) {
       subject: gettext('Confirm new sign-in to Firefox'),
       template: templateName,
       templateValues: {
-        alternativeLink: links.alternativeLink,
         device: this._formatUserAgentInfo(message),
         email: message.email,
         ip: message.ip,
@@ -385,7 +383,6 @@ module.exports = function (log) {
       subject: gettext('Reset your Firefox Account password'),
       template: templateName,
       templateValues: {
-        alternativeLink: links.alternativeLink,
         code: message.code,
         email: message.email,
         link: links.link,
@@ -508,7 +505,6 @@ module.exports = function (log) {
       subject: gettext('Firefox Account verified'),
       template: templateName,
       templateValues: {
-        alternativeLink: links.alternativeLink,
         androidUrl: links.androidLink,
         androidLinkAttributes: linkAttributes(links.androidLink),
         link: links.link,
@@ -592,7 +588,6 @@ module.exports = function (log) {
       subject: subject,
       template: templateName,
       templateValues: {
-        alternativeLink: links.alternativeLink,
         email: message.email,
         link: links.link,
         oneClickLink: links.oneClickLink,
@@ -636,7 +631,6 @@ module.exports = function (log) {
     var utmContent = templateNameToContentMap[templateName]
 
     if (primaryLink && utmContent) {
-      links['alternativeLink'] = this._generateUTMLink(primaryLink, query, templateName, utmContent + '-alternative')
       links['link'] = this._generateUTMLink(primaryLink, query, templateName, utmContent)
     }
     links['privacyUrl'] = this.createPrivacyLink(templateName)

--- a/partials/post_verify.html
+++ b/partials/post_verify.html
@@ -34,7 +34,6 @@
 <tr style="page-break-before: always">
   <td border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
     <br/>
-    <p width="310" class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 12px 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap: break-word">{{t "Alternatively:"}}<a href="{{{alternativeLink}}}" style="color: #0996f8; text-decoration: none; width: 310px !important; display:block;"><br/>{{{alternativeLink}}}</a></p>
     <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 12px 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap:break-word">{{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a %(supportLinkAttributes)s>Mozilla Support</a>."}}}</p>
   </td>
 </tr>

--- a/partials/recovery.html
+++ b/partials/recovery.html
@@ -34,7 +34,6 @@
 <tr style="page-break-before: always">
   <td border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
     <br/>
-    <p width="310" class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 12px 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap: break-word; word-break: break-all">{{t "Alternatively:"}}<a href="{{{alternativeLink}}}" style="color: #0996f8; text-decoration: none; width: 310px !important; display:block;"><br/><font style="word-break:break-all;">{{{alternativeLink}}}</font></a></p>
     <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 12px 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap:break-word">{{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a %(supportLinkAttributes)s>Mozilla Support</a>."}}}</p>
   </td>
 </tr>

--- a/partials/verify.html
+++ b/partials/verify.html
@@ -34,7 +34,6 @@
 <tr style="page-break-before: always">
   <td border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
     <br/>
-    <p width="310" class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 12px 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap: break-word; word-break: break-all">{{t "Alternatively:"}}<a href="{{{alternativeLink}}}" style="color: #0996f8; text-decoration: none; width: 310px !important; display:block;"><br/><font style="word-break:break-all;">{{{alternativeLink}}}</font></a></p>
     <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 12px 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap:break-word">{{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a %(supportLinkAttributes)s>Mozilla Support</a>."}}}</p>
   </td>
 </tr>

--- a/partials/verify_login.html
+++ b/partials/verify_login.html
@@ -36,7 +36,6 @@
 <tr style="page-break-before: always">
   <td border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
     <br/>
-    <p width="310" class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 12px 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap: break-word; word-break: break-all">{{t "Alternatively:"}}<a href="{{{alternativeLink}}}" style="color: #0996f8; text-decoration: none; width: 310px !important; display:block;"><br/><font style="word-break:break-all;">{{{alternativeLink}}}</font></a></p>
     <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 12px 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap:break-word">{{{t "If you suspect that someone is trying to gain access to your account, <a %(passwordChangeLinkAttributes)s>please change your password</a>."}}}
     </p>
   </td>

--- a/templates/post_verify.html
+++ b/templates/post_verify.html
@@ -49,7 +49,6 @@
 <tr style="page-break-before: always">
   <td border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
     <br/>
-    <p width="310" class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 12px 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap: break-word">{{t "Alternatively:"}}<a href="{{{alternativeLink}}}" style="color: #0996f8; text-decoration: none; width: 310px !important; display:block;"><br/>{{{alternativeLink}}}</a></p>
     <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 12px 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap:break-word">{{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a %(supportLinkAttributes)s>Mozilla Support</a>."}}}</p>
   </td>
 </tr>

--- a/templates/recovery.html
+++ b/templates/recovery.html
@@ -49,7 +49,6 @@
 <tr style="page-break-before: always">
   <td border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
     <br/>
-    <p width="310" class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 12px 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap: break-word; word-break: break-all">{{t "Alternatively:"}}<a href="{{{alternativeLink}}}" style="color: #0996f8; text-decoration: none; width: 310px !important; display:block;"><br/><font style="word-break:break-all;">{{{alternativeLink}}}</font></a></p>
     <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 12px 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap:break-word">{{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a %(supportLinkAttributes)s>Mozilla Support</a>."}}}</p>
   </td>
 </tr>

--- a/templates/verification_reminder_first.html
+++ b/templates/verification_reminder_first.html
@@ -49,7 +49,6 @@
 <tr style="page-break-before: always">
   <td border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
     <br/>
-    <p width="310" class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 12px 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap: break-word; word-break: break-all">{{t "Alternatively:"}}<a href="{{{alternativeLink}}}" style="color: #0996f8; text-decoration: none; width: 310px !important; display:block;"><br/><font style="word-break:break-all;">{{{alternativeLink}}}</font></a></p>
     <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 12px 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap:break-word">{{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a %(supportLinkAttributes)s>Mozilla Support</a>."}}}</p>
   </td>
 </tr>

--- a/templates/verification_reminder_second.html
+++ b/templates/verification_reminder_second.html
@@ -49,7 +49,6 @@
 <tr style="page-break-before: always">
   <td border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
     <br/>
-    <p width="310" class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 12px 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap: break-word; word-break: break-all">{{t "Alternatively:"}}<a href="{{{alternativeLink}}}" style="color: #0996f8; text-decoration: none; width: 310px !important; display:block;"><br/><font style="word-break:break-all;">{{{alternativeLink}}}</font></a></p>
     <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 12px 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap:break-word">{{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a %(supportLinkAttributes)s>Mozilla Support</a>."}}}</p>
   </td>
 </tr>

--- a/templates/verify.html
+++ b/templates/verify.html
@@ -49,7 +49,6 @@
 <tr style="page-break-before: always">
   <td border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
     <br/>
-    <p width="310" class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 12px 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap: break-word; word-break: break-all">{{t "Alternatively:"}}<a href="{{{alternativeLink}}}" style="color: #0996f8; text-decoration: none; width: 310px !important; display:block;"><br/><font style="word-break:break-all;">{{{alternativeLink}}}</font></a></p>
     <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 12px 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap:break-word">{{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a %(supportLinkAttributes)s>Mozilla Support</a>."}}}</p>
   </td>
 </tr>

--- a/templates/verify_login.html
+++ b/templates/verify_login.html
@@ -56,7 +56,6 @@
 <tr style="page-break-before: always">
   <td border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
     <br/>
-    <p width="310" class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 12px 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap: break-word; word-break: break-all">{{t "Alternatively:"}}<a href="{{{alternativeLink}}}" style="color: #0996f8; text-decoration: none; width: 310px !important; display:block;"><br/><font style="word-break:break-all;">{{{alternativeLink}}}</font></a></p>
     <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 12px 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap:break-word">{{{t "If you suspect that someone is trying to gain access to your account, <a %(passwordChangeLinkAttributes)s>please change your password</a>."}}}
     </p>
   </td>

--- a/test/local/mailer_tests.js
+++ b/test/local/mailer_tests.js
@@ -67,14 +67,6 @@ var typesContainIOSStoreLinks = [
   'postVerifyEmail'
 ]
 
-var typesContainAlternativeLinks = [
-  'postVerifyEmail',
-  'recoveryEmail',
-  'verificationReminderEmail',
-  'verifyEmail',
-  'verifyLoginEmail'
-]
-
 var typesContainLocationData = [
   'newDeviceLoginEmail',
   'unblockCodeEmail',
@@ -153,23 +145,6 @@ P.all(
             mailer[type](message)
           }
         )
-
-        if (includes(typesContainAlternativeLinks, type)){
-          test(
-            'test alternative link is in email template output for ' + type,
-            function (t) {
-              // Because the alternative link could be from anything, just test that
-              // it contains part of the `alternative` utm param
-              var alternativeBit = '-alternative'
-
-              mailer.mailer.sendMail = function (emailConfig) {
-                t.ok(includes(emailConfig.html, alternativeBit))
-                t.end()
-              }
-              mailer[type](message)
-            }
-          )
-        }
 
         if (includes(typesContainSupportLinks, type)) {
           test(


### PR DESCRIPTION
It's big. It detracts from the main link. It's so big that it's
impossible to place other content below it. @ryanfeeley wants it out!

fixes #228

@vbudhram - r?