### PR TITLE
fix(config): disable polling if pollTime === 0

### DIFF
--- a/config.js
+++ b/config.js
@@ -112,7 +112,7 @@ var conf = convict({
       default: 20
     },
     pollTime: {
-      doc: 'Poll duration in milliseconds.',
+      doc: 'Poll duration in milliseconds. 0 is disabled.',
       format: 'duration',
       default: '30 seconds'
     }

--- a/lib/verification-reminders.js
+++ b/lib/verification-reminders.js
@@ -75,6 +75,11 @@ module.exports = function (mailer, db, options) {
     poll: function poll () {
       var self = this
 
+      if (reminderConfig.pollTime === 0) {
+        log.info('poll', { message: 'polling is disabled' })
+        return
+      }
+
       setTimeout(function () {
         self.poll()
       }, reminderConfig.pollTime)

--- a/lib/verification-reminders.js
+++ b/lib/verification-reminders.js
@@ -73,17 +73,21 @@ module.exports = function (mailer, db, options) {
         })
     },
     poll: function poll () {
+      /* istanbul ignore next */
       var self = this
 
+      /* istanbul ignore next */
       if (reminderConfig.pollTime === 0) {
         log.info('poll', { message: 'polling is disabled' })
         return
       }
 
+      /* istanbul ignore next */
       setTimeout(function () {
         self.poll()
       }, reminderConfig.pollTime)
 
+      /* istanbul ignore next */
       self._continuousPoll()
     }
   }


### PR DESCRIPTION
r? - @vladikoff or @jbuck 

The database queries are extremely unfriendly to mysql replication. I have disabled `verificationReminders.rate` in the auth-server, but I'd like a graceful way to disable this polling entirely today, and we can revisit what other changes are needed on Monday.