### PR TITLE
refactor(templates): Add more location data to emails

### DIFF
--- a/mailer.js
+++ b/mailer.js
@@ -26,6 +26,7 @@ module.exports = function (log) {
     'unblockCode': 'new-unblock',
     'verifyEmail': 'welcome',
     'verifyLoginEmail': 'new-signin',
+    'verifySyncEmail': 'welcome-sync',
     'verificationReminderFirstEmail': 'hello-again-first',
     'verificationReminderSecondEmail': 'still-there-second',
     'verificationReminderEmail': 'hello-again-first'
@@ -46,7 +47,8 @@ module.exports = function (log) {
     'verificationReminderSecondEmail': 'activate',
     'verificationReminderEmail': 'activate',
     'verifyEmail': 'activate',
-    'verifyLoginEmail': 'confirm-signin'
+    'verifyLoginEmail': 'confirm-signin',
+    'verifySyncEmail': 'activate-sync',
   }
 
   function extend(target, source) {
@@ -257,6 +259,7 @@ module.exports = function (log) {
     log.trace({ op: 'mailer.verifyEmail', email: message.email, uid: message.uid })
 
     var templateName = 'verifyEmail'
+    var subject = 'Verify your Firefox Account'
     var query = {
       uid: message.uid,
       code: message.code
@@ -280,17 +283,26 @@ module.exports = function (log) {
       headers['X-Flow-Begin-Time'] = message.flowBeginTime
     }
 
+    if (message.service === 'sync') {
+      subject = 'Confirm your email and start to sync!'
+      templateName = 'verifySyncEmail'
+    }
+
     return this.send({
       acceptLanguage: message.acceptLanguage,
       email: message.email,
       headers: headers,
-      subject: gettext('Verify your Firefox Account'),
+      subject: gettext(subject),
       template: templateName,
       templateValues: {
+        device: this._formatUserAgentInfo(message),
         email: message.email,
+        ip: message.ip,
         link: links.link,
+        location: this._constructLocationString(message),
         oneClickLink: links.oneClickLink,
         privacyUrl: links.privacyUrl,
+        sync: message.service,
         supportUrl: links.supportUrl,
         supportLinkAttributes: links.supportLinkAttributes
       },
@@ -424,11 +436,15 @@ module.exports = function (log) {
       template: templateName,
       templateValues: {
         code: message.code,
+        device: this._formatUserAgentInfo(message),
         email: message.email,
+        ip: message.ip,
         link: links.link,
+        location: this._constructLocationString(message),
         privacyUrl: links.privacyUrl,
         supportUrl: links.supportUrl,
-        supportLinkAttributes: links.supportLinkAttributes
+        supportLinkAttributes: links.supportLinkAttributes,
+        timestamp: this._constructLocalTimeString(message.timeZone, message.acceptLanguage)
       },
       uid: message.uid
     })
@@ -455,11 +471,15 @@ module.exports = function (log) {
       subject: gettext('Your Firefox Account password has been changed'),
       template: templateName,
       templateValues: {
+        device: this._formatUserAgentInfo(message),
+        ip: message.ip,
+        location: this._constructLocationString(message),
         privacyUrl: links.privacyUrl,
         resetLink: links.resetLink,
         resetLinkAttributes: links.resetLinkAttributes,
         supportLinkAttributes: links.supportLinkAttributes,
-        supportUrl: links.supportUrl
+        supportUrl: links.supportUrl,
+        timestamp: this._constructLocalTimeString(message.timeZone, message.acceptLanguage)
       },
       uid: message.uid
     })

--- a/mailer.js
+++ b/mailer.js
@@ -259,7 +259,7 @@ module.exports = function (log) {
     log.trace({ op: 'mailer.verifyEmail', email: message.email, uid: message.uid })
 
     var templateName = 'verifyEmail'
-    var subject = 'Verify your Firefox Account'
+    var subject = gettext('Verify your Firefox Account')
     var query = {
       uid: message.uid,
       code: message.code
@@ -284,7 +284,7 @@ module.exports = function (log) {
     }
 
     if (message.service === 'sync') {
-      subject = 'Confirm your email and start to sync!'
+      subject = gettext('Confirm your email and start to sync!')
       templateName = 'verifySyncEmail'
     }
 
@@ -292,7 +292,7 @@ module.exports = function (log) {
       acceptLanguage: message.acceptLanguage,
       email: message.email,
       headers: headers,
-      subject: gettext(subject),
+      subject: subject,
       template: templateName,
       templateValues: {
         device: this._formatUserAgentInfo(message),

--- a/partials/base/base.html
+++ b/partials/base/base.html
@@ -11,7 +11,12 @@
 <!--Logo-->
 <tr style="page-break-before: always">
   <td align="center" id="firefox-logo" style="padding: 20px 0;">
-    <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+    {{^if sync}}
+      <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+    {{/if}}
+    {{#if sync}}
+      <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/fxa_dec2016.jpeg" height="152" width="310" alt="" style="-ms-interpolation-mode: bicubic;" />
+    {{/if}}
   </td>
 </tr>
 

--- a/partials/location/location.html
+++ b/partials/location/location.html
@@ -2,4 +2,3 @@
 {{#if location }}<span style="display:block;margin:2px 0;">{{ location }}</span>{{/if}}
 {{#if ip }}<span style="display:block;margin:2px 0;">{{t "IP address: %(ip)s" }}</span>{{/if}}
 {{#if timestamp }}<span style="display:block;margin:2px 0;">{{ timestamp }}</span>{{/if}}
-

--- a/partials/password_changed.html
+++ b/partials/password_changed.html
@@ -5,7 +5,9 @@
 <tr style="page-break-before: always">
   <td valign="top">
     <h1 style="font-family: sans-serif; font-weight: normal; margin: 0 0 24px 0; text-align: center;">{{t "Password changed successfully"}}</h1>
-    <p class="primary" style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 12px 0; text-align: center;">{{t "Your Firefox Account password has been successfully changed." }}</p>
+    <p class="primary" style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 12px 0; text-align: center;">{{t "Your Firefox Account password was successfully changed from the following device:" }}<br/><br/>
+      <% include "./location/location.html" %>
+    </p>
   </td>
 </tr>
 

--- a/partials/recovery.html
+++ b/partials/recovery.html
@@ -5,7 +5,9 @@
 <tr style="page-break-before: always">
   <td valign="top">
     <h1 style="font-family: sans-serif; font-weight: normal; margin: 0 0 24px 0; text-align: center;">{{t "Forgot your password?"}}</h1>
-    <p class="primary" style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 24px 0; text-align: center;">{{{t "Click the button within the next hour to set a new password for your Firefox Account." }}}</p>
+    <p class="primary" style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 24px 0; text-align: center;">{{{t "Click the button within the next hour to set a new password for your Firefox Account. The request came from the following device:" }}}<br/><br/>
+      <% include "./location/location.html" %>
+    </p>
   </td>
 </tr>
 

--- a/partials/verify_sync.html
+++ b/partials/verify_sync.html
@@ -1,0 +1,63 @@
+<% extends "partials/base/base.html" %>
+
+<% block content %>
+<!--Header Area-->
+<tr style="page-break-before: always">
+  <td valign="top">
+    <h1 style="font-family: sans-serif; font-weight: normal; margin: 0 0 24px 0; text-align: center;"><% block verify_title %>{{t "Ready, set sync"}}<% endblock %></h1>
+    <p class="primary" style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 24px 0; text-align: center;"><% block verify_content %>{{t "Confirm you’ve received this email and we’ll help you install and sync Firefox on all your devices starting with:"}}<br/><br/>
+      <% include "./location/location.html" %>
+      <% endblock %>
+    </p>
+  </td>
+</tr>
+
+<!--Button Area-->
+<tr height="50">
+  <td align="center" valign="top">
+    <table border="0" cellpadding="0" cellspacing="0" height="100%" width="100%" id="email-button" style="-webkit-text-size-adjust: 100%; border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #0996f8; border-radius: 4px; height: 50px; width: 310px !important;">
+      <tr style="page-break-before: always">
+        <td align="center" valign="middle" id="button-content" style="font-family: sans-serif; font-weight: normal; text-align: center; margin: 0; color: #ffffff; font-size: 20px; line-height: 100%;">
+          <!--[if mso]>
+          <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="{{{link}}}" style="width:280px;height:40px;v-text-anchor:middle;" arcsize="10%" stroke="f" fillcolor="#0996f8">
+            <w:anchorlock/>
+            <center>
+          <![endif]-->
+          <a href="{{{link}}}" id="button-link" style="font-family:sans-serif; color: #fff; display: block; padding: 15px; text-decoration: none; width: 280px;">{{t "Verify email "}}&rarr;</a>
+          <!--[if mso]>
+          </center>
+          </v:roundrect>
+          <![endif]-->
+        </td>
+      </tr>
+    </table>
+  </td>
+</tr>
+
+<!--Caption Area-->
+<tr style="page-break-before: always">
+  <td border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
+    <br/>
+    <p class="primary" style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 24px 0; text-align: center;">{{t "Once confirmed, we will help you install and connect Firefox on at least one other device."}}
+  </td>
+</tr>
+
+<!--Button Area-->
+<tr style="page-break-before: always">
+  <td border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
+    <br/>
+    <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 12px 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 13px; width: 310px !important; word-wrap:break-word">{{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a %(supportLinkAttributes)s>Mozilla Support</a>."}}}</p>
+  </td>
+</tr>
+<% endblock %>
+
+<% block after_table %>
+<div itemscope itemtype="https://schema.org/EmailMessage">
+  <div itemprop="potentialAction" itemscope itemtype="https://schema.org/ViewAction">
+    <link itemprop="target" href="{{{oneClickLink}}}"/>
+    <meta itemprop="name" content="{{t 'Verify Email'}}"/>
+    <meta itemprop="url" content="{{{oneClickLink}}}"/>
+  </div>
+  <meta itemprop="description" content="{{t 'Verify your email to finish your Firefox Account registration'}}"/>
+</div>
+<% endblock %>

--- a/templates/index.js
+++ b/templates/index.js
@@ -59,7 +59,8 @@ module.exports = function () {
       'verification_reminder_first',
       'verification_reminder_second',
       'verify',
-      'verify_login'
+      'verify_login',
+      'verify_sync'
     ].map(loadTemplates)
   )
   .then(

--- a/templates/new_device_login.html
+++ b/templates/new_device_login.html
@@ -31,7 +31,6 @@
 {{#if ip }}<span style="display:block;margin:2px 0;">{{t "IP address: %(ip)s" }}</span>{{/if}}
 {{#if timestamp }}<span style="display:block;margin:2px 0;">{{ timestamp }}</span>{{/if}}
 
-
 </p>
   </td>
 </tr>

--- a/templates/new_device_login.html
+++ b/templates/new_device_login.html
@@ -11,7 +11,12 @@
 <!--Logo-->
 <tr style="page-break-before: always">
   <td align="center" id="firefox-logo" style="padding: 20px 0;">
-    <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+    {{^if sync}}
+      <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+    {{/if}}
+    {{#if sync}}
+      <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/fxa_dec2016.jpeg" height="152" width="310" alt="" style="-ms-interpolation-mode: bicubic;" />
+    {{/if}}
   </td>
 </tr>
 

--- a/templates/password_changed.html
+++ b/templates/password_changed.html
@@ -31,7 +31,6 @@
 {{#if ip }}<span style="display:block;margin:2px 0;">{{t "IP address: %(ip)s" }}</span>{{/if}}
 {{#if timestamp }}<span style="display:block;margin:2px 0;">{{ timestamp }}</span>{{/if}}
 
-
     </p>
   </td>
 </tr>

--- a/templates/password_changed.html
+++ b/templates/password_changed.html
@@ -11,7 +11,12 @@
 <!--Logo-->
 <tr style="page-break-before: always">
   <td align="center" id="firefox-logo" style="padding: 20px 0;">
-    <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+    {{^if sync}}
+      <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+    {{/if}}
+    {{#if sync}}
+      <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/fxa_dec2016.jpeg" height="152" width="310" alt="" style="-ms-interpolation-mode: bicubic;" />
+    {{/if}}
   </td>
 </tr>
 
@@ -20,7 +25,14 @@
 <tr style="page-break-before: always">
   <td valign="top">
     <h1 style="font-family: sans-serif; font-weight: normal; margin: 0 0 24px 0; text-align: center;">{{t "Password changed successfully"}}</h1>
-    <p class="primary" style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 12px 0; text-align: center;">{{t "Your Firefox Account password has been successfully changed." }}</p>
+    <p class="primary" style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 12px 0; text-align: center;">{{t "Your Firefox Account password was successfully changed from the following device:" }}<br/><br/>
+      <span style="display:block;margin:2px 0;">{{{ device }}}</span>
+{{#if location }}<span style="display:block;margin:2px 0;">{{ location }}</span>{{/if}}
+{{#if ip }}<span style="display:block;margin:2px 0;">{{t "IP address: %(ip)s" }}</span>{{/if}}
+{{#if timestamp }}<span style="display:block;margin:2px 0;">{{ timestamp }}</span>{{/if}}
+
+
+    </p>
   </td>
 </tr>
 

--- a/templates/password_changed.txt
+++ b/templates/password_changed.txt
@@ -1,5 +1,10 @@
 {{t "Password changed successfully" }}
-{{t "Your Firefox Account password has been successfully changed." }}
+{{t "Your Firefox Account password was successfully changed from the following device:" }}
+
+{{ device }}
+{{#if location}}{{ location }}{{/if}}
+{{#if ip}}{{t "IP address: %(ip)s" }}{{/if}}
+{{#if timestamp}}{{ timestamp }}{{/if}}
 
 {{{t "This is an automated email; if you didn’t change the password to your Firefox Account, you should reset it immediately at %(resetLink)s" }}}
 

--- a/templates/password_reset.html
+++ b/templates/password_reset.html
@@ -11,7 +11,12 @@
 <!--Logo-->
 <tr style="page-break-before: always">
   <td align="center" id="firefox-logo" style="padding: 20px 0;">
-    <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+    {{^if sync}}
+      <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+    {{/if}}
+    {{#if sync}}
+      <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/fxa_dec2016.jpeg" height="152" width="310" alt="" style="-ms-interpolation-mode: bicubic;" />
+    {{/if}}
   </td>
 </tr>
 

--- a/templates/post_verify.html
+++ b/templates/post_verify.html
@@ -11,7 +11,12 @@
 <!--Logo-->
 <tr style="page-break-before: always">
   <td align="center" id="firefox-logo" style="padding: 20px 0;">
-    <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+    {{^if sync}}
+      <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+    {{/if}}
+    {{#if sync}}
+      <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/fxa_dec2016.jpeg" height="152" width="310" alt="" style="-ms-interpolation-mode: bicubic;" />
+    {{/if}}
   </td>
 </tr>
 

--- a/templates/recovery.html
+++ b/templates/recovery.html
@@ -31,7 +31,6 @@
 {{#if ip }}<span style="display:block;margin:2px 0;">{{t "IP address: %(ip)s" }}</span>{{/if}}
 {{#if timestamp }}<span style="display:block;margin:2px 0;">{{ timestamp }}</span>{{/if}}
 
-
     </p>
   </td>
 </tr>

--- a/templates/recovery.html
+++ b/templates/recovery.html
@@ -11,7 +11,12 @@
 <!--Logo-->
 <tr style="page-break-before: always">
   <td align="center" id="firefox-logo" style="padding: 20px 0;">
-    <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+    {{^if sync}}
+      <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+    {{/if}}
+    {{#if sync}}
+      <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/fxa_dec2016.jpeg" height="152" width="310" alt="" style="-ms-interpolation-mode: bicubic;" />
+    {{/if}}
   </td>
 </tr>
 
@@ -20,7 +25,14 @@
 <tr style="page-break-before: always">
   <td valign="top">
     <h1 style="font-family: sans-serif; font-weight: normal; margin: 0 0 24px 0; text-align: center;">{{t "Forgot your password?"}}</h1>
-    <p class="primary" style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 24px 0; text-align: center;">{{{t "Click the button within the next hour to set a new password for your Firefox Account." }}}</p>
+    <p class="primary" style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 24px 0; text-align: center;">{{{t "Click the button within the next hour to set a new password for your Firefox Account. The request came from the following device:" }}}<br/><br/>
+      <span style="display:block;margin:2px 0;">{{{ device }}}</span>
+{{#if location }}<span style="display:block;margin:2px 0;">{{ location }}</span>{{/if}}
+{{#if ip }}<span style="display:block;margin:2px 0;">{{t "IP address: %(ip)s" }}</span>{{/if}}
+{{#if timestamp }}<span style="display:block;margin:2px 0;">{{ timestamp }}</span>{{/if}}
+
+
+    </p>
   </td>
 </tr>
 

--- a/templates/unblock_code.html
+++ b/templates/unblock_code.html
@@ -11,7 +11,12 @@
 <!--Logo-->
 <tr style="page-break-before: always">
   <td align="center" id="firefox-logo" style="padding: 20px 0;">
-    <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+    {{^if sync}}
+      <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+    {{/if}}
+    {{#if sync}}
+      <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/fxa_dec2016.jpeg" height="152" width="310" alt="" style="-ms-interpolation-mode: bicubic;" />
+    {{/if}}
   </td>
 </tr>
 

--- a/templates/unblock_code.html
+++ b/templates/unblock_code.html
@@ -31,7 +31,6 @@
 {{#if ip }}<span style="display:block;margin:2px 0;">{{t "IP address: %(ip)s" }}</span>{{/if}}
 {{#if timestamp }}<span style="display:block;margin:2px 0;">{{ timestamp }}</span>{{/if}}
 
-
   </td>
 </tr>
 <tr style="page-break-before: always">

--- a/templates/verification_reminder_first.html
+++ b/templates/verification_reminder_first.html
@@ -11,7 +11,12 @@
 <!--Logo-->
 <tr style="page-break-before: always">
   <td align="center" id="firefox-logo" style="padding: 20px 0;">
-    <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+    {{^if sync}}
+      <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+    {{/if}}
+    {{#if sync}}
+      <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/fxa_dec2016.jpeg" height="152" width="310" alt="" style="-ms-interpolation-mode: bicubic;" />
+    {{/if}}
   </td>
 </tr>
 

--- a/templates/verify.html
+++ b/templates/verify.html
@@ -11,7 +11,12 @@
 <!--Logo-->
 <tr style="page-break-before: always">
   <td align="center" id="firefox-logo" style="padding: 20px 0;">
-    <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+    {{^if sync}}
+      <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+    {{/if}}
+    {{#if sync}}
+      <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/fxa_dec2016.jpeg" height="152" width="310" alt="" style="-ms-interpolation-mode: bicubic;" />
+    {{/if}}
   </td>
 </tr>
 

--- a/templates/verify_login.html
+++ b/templates/verify_login.html
@@ -31,7 +31,6 @@
 {{#if ip }}<span style="display:block;margin:2px 0;">{{t "IP address: %(ip)s" }}</span>{{/if}}
 {{#if timestamp }}<span style="display:block;margin:2px 0;">{{ timestamp }}</span>{{/if}}
 
-
     </p>
   </td>
 </tr>

--- a/templates/verify_login.html
+++ b/templates/verify_login.html
@@ -11,7 +11,12 @@
 <!--Logo-->
 <tr style="page-break-before: always">
   <td align="center" id="firefox-logo" style="padding: 20px 0;">
-    <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+    {{^if sync}}
+      <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+    {{/if}}
+    {{#if sync}}
+      <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/fxa_dec2016.jpeg" height="152" width="310" alt="" style="-ms-interpolation-mode: bicubic;" />
+    {{/if}}
   </td>
 </tr>
 

--- a/templates/verify_sync.html
+++ b/templates/verify_sync.html
@@ -24,8 +24,16 @@
 <!--Header Area-->
 <tr style="page-break-before: always">
   <td valign="top">
-    <h1 style="font-family: sans-serif; font-weight: normal; margin: 0 0 24px 0; text-align: center;">{{t "Still there?"}}</h1>
-    <p class="primary" style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 24px 0; text-align: center;">{{{t "A week ago you created a Firefox Account, but never verified it. We’re worried about you. Confirm this email address to activate your account and let us know you're okay."}}}</p>
+    <h1 style="font-family: sans-serif; font-weight: normal; margin: 0 0 24px 0; text-align: center;">{{t "Ready, set sync"}}</h1>
+    <p class="primary" style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 24px 0; text-align: center;">{{t "Confirm you’ve received this email and we’ll help you install and sync Firefox on all your devices starting with:"}}<br/><br/>
+      <span style="display:block;margin:2px 0;">{{{ device }}}</span>
+{{#if location }}<span style="display:block;margin:2px 0;">{{ location }}</span>{{/if}}
+{{#if ip }}<span style="display:block;margin:2px 0;">{{t "IP address: %(ip)s" }}</span>{{/if}}
+{{#if timestamp }}<span style="display:block;margin:2px 0;">{{ timestamp }}</span>{{/if}}
+
+
+      
+    </p>
   </td>
 </tr>
 
@@ -40,7 +48,7 @@
             <w:anchorlock/>
             <center>
           <![endif]-->
-          <a href="{{{link}}}" id="button-link" style="font-family:sans-serif; color: #fff; display: block; padding: 15px; text-decoration: none; width: 280px;">{{t "Activate now"}}</a>
+          <a href="{{{link}}}" id="button-link" style="font-family:sans-serif; color: #fff; display: block; padding: 15px; text-decoration: none; width: 280px;">{{t "Verify email "}}&rarr;</a>
           <!--[if mso]>
           </center>
           </v:roundrect>
@@ -50,6 +58,15 @@
     </table>
   </td>
 </tr>
+
+<!--Caption Area-->
+<tr style="page-break-before: always">
+  <td border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
+    <br/>
+    <p class="primary" style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 24px 0; text-align: center;">{{t "Once confirmed, we will help you install and connect Firefox on at least one other device."}}
+  </td>
+</tr>
+
 <!--Button Area-->
 <tr style="page-break-before: always">
   <td border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">

--- a/templates/verify_sync.html
+++ b/templates/verify_sync.html
@@ -31,7 +31,6 @@
 {{#if ip }}<span style="display:block;margin:2px 0;">{{t "IP address: %(ip)s" }}</span>{{/if}}
 {{#if timestamp }}<span style="display:block;margin:2px 0;">{{ timestamp }}</span>{{/if}}
 
-
       
     </p>
   </td>

--- a/templates/verify_sync.txt
+++ b/templates/verify_sync.txt
@@ -1,13 +1,14 @@
-{{t "Forgot your password?"}}
+{{t "Ready, set sync"}}
 
-{{{t "Click the button within the next hour to set a new password for your Firefox Account. The request came from the following device:" }}}
+{{{t "Confirm you’ve received this email and we’ll help you install and sync Firefox on all your devices starting with:" }}}
 
 {{ device }}
 {{#if location}}{{ location }}{{/if}}
 {{#if ip}}{{t "IP address: %(ip)s" }}{{/if}}
-{{#if timestamp}}{{ timestamp }}{{/if}}
 
-{{t "Reset password"}} {{{link}}}
+{{t "Verify email "}} &rarr; {{{link}}}
+
+{{t "Once confirmed, we will help you install and connect Firefox on at least one other device."}}
 
 {{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit %(supportUrl)s"}}}
 

--- a/test/local/mailer_tests.js
+++ b/test/local/mailer_tests.js
@@ -71,7 +71,10 @@ var typesContainIOSStoreLinks = [
 
 var typesContainLocationData = [
   'newDeviceLoginEmail',
+  'passwordChangedEmail',
   'unblockCodeEmail',
+  'recoveryEmail',
+  'verifyEmail',
   'verifyLoginEmail'
 ]
 
@@ -90,6 +93,7 @@ function getLocationMessage (location) {
     email: 'a@b.com',
     ip: '219.129.234.194',
     location: location,
+    service: 'sync',
     timeZone: 'America/Los_Angeles'
   }
 }
@@ -111,7 +115,7 @@ P.all(
           code: 'abc123',
           email: 'a@b.com',
           locations: [],
-          service: 'service',
+          service: 'sync',
           uid: 'uid',
           unblockCode: 'AS6334PK',
           flowId: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
@@ -127,6 +131,9 @@ P.all(
               if (type === 'verificationReminderEmail') {
                 // Handle special case for verification reminders
                 t.equal(templateName, 'verificationReminderFirstEmail' || 'verificationReminderSecondEmail')
+              } else if (type === 'verifyEmail') {
+                // Handle special case for verify email
+                t.equal(templateName, 'verifySyncEmail')
               } else {
                 t.equal(templateName, type)
               }


### PR DESCRIPTION
This PR adds adds a new verify account sync template. This does not change the verify account email for non-sync users. It also adds location data to

- verify sync account email
- password reset email
- password change success email

It also contains some slight text tweaks to the emails.

Fixes #189 