### PR TITLE
feat(mailer): add support for sending SMS messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
 
 var P = require('bluebird')
 var createMailer = require('./mailer')
+var createSms = require('./lib/sms')
 
 module.exports = function (log, config, sender) {
   var Mailer = createMailer(log)
@@ -15,7 +16,10 @@ module.exports = function (log, config, sender) {
   )
   .spread(
     function (translator, templates) {
-      return new Mailer(translator, templates, config.mail, sender)
+      return {
+        email: new Mailer(translator, templates, config.mail, sender),
+        sms: createSms(log, translator, templates, config.sms)
+      }
     }
   )
 }

--- a/lib/sms.js
+++ b/lib/sms.js
@@ -1,0 +1,98 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+var Nexmo = require('nexmo')
+var P = require('bluebird')
+
+var TEMPLATE_NAMES = new Map([
+  [ 1, 'installFirefox' ]
+])
+
+module.exports = function (log, translator, templates, smsConfig) {
+  var nexmo = new Nexmo({
+    apiKey: smsConfig.apiKey,
+    apiSecret: smsConfig.apiSecret
+  })
+  var sendSms = P.promisify(nexmo.message.sendSms, { context: nexmo.message })
+
+  return {
+    send: function (phoneNumber, senderId, messageId, acceptLanguage) {
+      log.trace({
+        op: 'sms.send',
+        senderId: senderId,
+        messageId: messageId,
+        acceptLanguage: acceptLanguage
+      })
+
+      return P.resolve()
+        .then(function () {
+          var message = getMessage(messageId, acceptLanguage)
+
+          return sendSms(senderId, phoneNumber, message.trim())
+        })
+        .then(function (result) {
+          var resultCount = result.messages && result.messages.length
+          if (resultCount !== 1) {
+            // I don't expect this condition to be entered, certainly I haven't
+            // seen it in testing. But because I'm making an assumption about
+            // the result format, I want to log an error if my assumption proves
+            // to be wrong in production.
+            log.error({ op: 'sms.send', err: new Error('Unexpected result count'), resultCount: resultCount })
+          }
+
+          result = result.messages[0]
+          var status = result.status
+
+          // https://docs.nexmo.com/messaging/sms-api/api-reference#status-codes
+          if (status === '0') {
+            log.info({
+              op: 'sms.send.success',
+              senderId: senderId,
+              messageId: messageId,
+              acceptLanguage: acceptLanguage
+            })
+          } else {
+            var reason = result['error-text']
+            fail('Message rejected', {
+              status: 500,
+              reason: reason,
+              reasonCode: status
+            })
+          }
+        })
+    }
+  }
+
+  function getMessage (messageId, acceptLanguage) {
+    var templateName = TEMPLATE_NAMES.get(messageId)
+    var template = templates['sms.' + templateName]
+
+    if (! template) {
+      fail('Invalid message id', { status: 400 })
+    }
+
+    return template({
+      link: smsConfig[templateName + 'Link'],
+      translator: translator(acceptLanguage)
+    }).text
+  }
+
+  // If/when fxa-auth-mailer is moved into the auth server repo,
+  // calls to this function can be replaced with the auth server's
+  // AppError methods directly.
+  function fail (message, properties) {
+    log.error({ op: 'sms.send', err: message })
+
+    var error = new Error(message)
+    if (properties) {
+      Object.keys(properties).forEach(function (key) {
+        error[key] = properties[key]
+      })
+    }
+
+    throw error
+  }
+}

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1476,7 +1476,7 @@
                 },
                 "minimist": {
                   "version": "1.2.0",
-                  "from": "minimist@>=1.1.3 <2.0.0",
+                  "from": "minimist@1.2.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                 },
                 "normalize-package-data": {
@@ -1951,7 +1951,7 @@
           "dependencies": {
             "argparse": {
               "version": "1.0.9",
-              "from": "argparse@>=1.0.2 <2.0.0",
+              "from": "argparse@>=1.0.7 <2.0.0",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
               "dependencies": {
                 "sprintf-js": {
@@ -2618,7 +2618,7 @@
                 },
                 "normalize-package-data": {
                   "version": "2.3.5",
-                  "from": "normalize-package-data@>=2.3.2 <3.0.0",
+                  "from": "normalize-package-data@>=2.3.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
                   "dependencies": {
                     "is-builtin-module": {
@@ -2783,7 +2783,7 @@
                   "dependencies": {
                     "camelcase": {
                       "version": "2.1.1",
-                      "from": "camelcase@>=2.0.0 <3.0.0",
+                      "from": "camelcase@>=2.0.1 <3.0.0",
                       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
                     }
                   }
@@ -4065,8 +4065,8 @@
     },
     "grunt-nunjucks-2-html": {
       "version": "0.3.4",
-      "from": "vitkarpov/grunt-nunjucks-2-html#1900f91a756b2eaf900b20",
-      "resolved": "git://github.com/vitkarpov/grunt-nunjucks-2-html.git#1900f91a756b2eaf900b20ca7a28b10267ca55ba",
+      "from": "git+https://github.com/vitkarpov/grunt-nunjucks-2-html.git#1900f91a756b2eaf900b20",
+      "resolved": "git+https://github.com/vitkarpov/grunt-nunjucks-2-html.git#1900f91a756b2eaf900b20ca7a28b10267ca55ba",
       "dependencies": {
         "async": {
           "version": "1.5.2",
@@ -4405,6 +4405,630 @@
                       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
                     }
                   }
+                },
+                "fsevents": {
+                  "version": "1.0.17",
+                  "from": "fsevents@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.17.tgz",
+                  "dependencies": {
+                    "nan": {
+                      "version": "2.5.1",
+                      "from": "nan@>=2.3.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-2.5.1.tgz"
+                    },
+                    "node-pre-gyp": {
+                      "version": "0.6.32",
+                      "from": "node-pre-gyp@>=0.6.29 <0.7.0",
+                      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.32.tgz"
+                    },
+                    "abbrev": {
+                      "version": "1.0.9",
+                      "from": "abbrev@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
+                    },
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                    },
+                    "ansi-styles": {
+                      "version": "2.2.1",
+                      "from": "ansi-styles@>=2.2.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                    },
+                    "aproba": {
+                      "version": "1.0.4",
+                      "from": "aproba@>=1.0.3 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz"
+                    },
+                    "are-we-there-yet": {
+                      "version": "1.1.2",
+                      "from": "are-we-there-yet@>=1.1.2 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz"
+                    },
+                    "asn1": {
+                      "version": "0.2.3",
+                      "from": "asn1@>=0.2.3 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+                    },
+                    "assert-plus": {
+                      "version": "0.2.0",
+                      "from": "assert-plus@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+                    },
+                    "asynckit": {
+                      "version": "0.4.0",
+                      "from": "asynckit@>=0.4.0 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
+                    },
+                    "aws-sign2": {
+                      "version": "0.6.0",
+                      "from": "aws-sign2@>=0.6.0 <0.7.0",
+                      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+                    },
+                    "aws4": {
+                      "version": "1.5.0",
+                      "from": "aws4@>=1.2.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz"
+                    },
+                    "balanced-match": {
+                      "version": "0.4.2",
+                      "from": "balanced-match@>=0.4.1 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+                    },
+                    "bcrypt-pbkdf": {
+                      "version": "1.0.0",
+                      "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz"
+                    },
+                    "boom": {
+                      "version": "2.10.1",
+                      "from": "boom@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                    },
+                    "block-stream": {
+                      "version": "0.0.9",
+                      "from": "block-stream@*",
+                      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
+                    },
+                    "brace-expansion": {
+                      "version": "1.1.6",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
+                    },
+                    "buffer-shims": {
+                      "version": "1.0.0",
+                      "from": "buffer-shims@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+                    },
+                    "caseless": {
+                      "version": "0.11.0",
+                      "from": "caseless@>=0.11.0 <0.12.0",
+                      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+                    },
+                    "code-point-at": {
+                      "version": "1.1.0",
+                      "from": "code-point-at@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
+                    },
+                    "combined-stream": {
+                      "version": "1.0.5",
+                      "from": "combined-stream@>=1.0.5 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
+                    },
+                    "commander": {
+                      "version": "2.9.0",
+                      "from": "commander@>=2.9.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    },
+                    "console-control-strings": {
+                      "version": "1.1.0",
+                      "from": "console-control-strings@>=1.1.0 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
+                    },
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    },
+                    "cryptiles": {
+                      "version": "2.0.5",
+                      "from": "cryptiles@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                    },
+                    "debug": {
+                      "version": "2.2.0",
+                      "from": "debug@>=2.2.0 <2.3.0",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+                    },
+                    "deep-extend": {
+                      "version": "0.4.1",
+                      "from": "deep-extend@>=0.4.0 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
+                    },
+                    "delayed-stream": {
+                      "version": "1.0.0",
+                      "from": "delayed-stream@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                    },
+                    "delegates": {
+                      "version": "1.0.0",
+                      "from": "delegates@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
+                    },
+                    "ecc-jsbn": {
+                      "version": "0.1.1",
+                      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.5",
+                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                    },
+                    "extend": {
+                      "version": "3.0.0",
+                      "from": "extend@>=3.0.0 <3.1.0",
+                      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+                    },
+                    "extsprintf": {
+                      "version": "1.0.2",
+                      "from": "extsprintf@1.0.2",
+                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                    },
+                    "forever-agent": {
+                      "version": "0.6.1",
+                      "from": "forever-agent@>=0.6.1 <0.7.0",
+                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+                    },
+                    "form-data": {
+                      "version": "2.1.2",
+                      "from": "form-data@>=2.1.1 <2.2.0",
+                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz"
+                    },
+                    "fs.realpath": {
+                      "version": "1.0.0",
+                      "from": "fs.realpath@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+                    },
+                    "fstream": {
+                      "version": "1.0.10",
+                      "from": "fstream@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz"
+                    },
+                    "fstream-ignore": {
+                      "version": "1.0.5",
+                      "from": "fstream-ignore@>=1.0.5 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz"
+                    },
+                    "gauge": {
+                      "version": "2.7.2",
+                      "from": "gauge@>=2.7.1 <2.8.0",
+                      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.2.tgz"
+                    },
+                    "generate-function": {
+                      "version": "2.0.0",
+                      "from": "generate-function@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                    },
+                    "generate-object-property": {
+                      "version": "1.2.0",
+                      "from": "generate-object-property@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
+                    },
+                    "glob": {
+                      "version": "7.1.1",
+                      "from": "glob@>=7.0.5 <8.0.0",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
+                    },
+                    "graceful-fs": {
+                      "version": "4.1.11",
+                      "from": "graceful-fs@>=4.1.2 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+                    },
+                    "graceful-readlink": {
+                      "version": "1.0.1",
+                      "from": "graceful-readlink@>=1.0.0",
+                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                    },
+                    "har-validator": {
+                      "version": "2.0.6",
+                      "from": "har-validator@>=2.0.6 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz"
+                    },
+                    "has-ansi": {
+                      "version": "2.0.0",
+                      "from": "has-ansi@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
+                    },
+                    "has-unicode": {
+                      "version": "2.0.1",
+                      "from": "has-unicode@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz"
+                    },
+                    "hawk": {
+                      "version": "3.1.3",
+                      "from": "hawk@>=3.1.3 <3.2.0",
+                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
+                    },
+                    "hoek": {
+                      "version": "2.16.3",
+                      "from": "hoek@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                    },
+                    "http-signature": {
+                      "version": "1.1.1",
+                      "from": "http-signature@>=1.1.0 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
+                    },
+                    "inflight": {
+                      "version": "1.0.6",
+                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                    },
+                    "ini": {
+                      "version": "1.3.4",
+                      "from": "ini@>=1.3.0 <1.4.0",
+                      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                    },
+                    "is-fullwidth-code-point": {
+                      "version": "1.0.0",
+                      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
+                    },
+                    "is-my-json-valid": {
+                      "version": "2.15.0",
+                      "from": "is-my-json-valid@>=2.12.4 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz"
+                    },
+                    "is-property": {
+                      "version": "1.0.2",
+                      "from": "is-property@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                    },
+                    "is-typedarray": {
+                      "version": "1.0.0",
+                      "from": "is-typedarray@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "from": "isarray@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                    },
+                    "jodid25519": {
+                      "version": "1.0.2",
+                      "from": "jodid25519@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                    },
+                    "isstream": {
+                      "version": "0.1.2",
+                      "from": "isstream@>=0.1.2 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                    },
+                    "jsbn": {
+                      "version": "0.1.0",
+                      "from": "jsbn@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+                    },
+                    "json-schema": {
+                      "version": "0.2.3",
+                      "from": "json-schema@0.2.3",
+                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
+                    },
+                    "json-stringify-safe": {
+                      "version": "5.0.1",
+                      "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                    },
+                    "jsonpointer": {
+                      "version": "4.0.1",
+                      "from": "jsonpointer@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz"
+                    },
+                    "jsprim": {
+                      "version": "1.3.1",
+                      "from": "jsprim@>=1.2.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz"
+                    },
+                    "mime-db": {
+                      "version": "1.25.0",
+                      "from": "mime-db@>=1.25.0 <1.26.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz"
+                    },
+                    "mime-types": {
+                      "version": "2.1.13",
+                      "from": "mime-types@>=2.1.7 <2.2.0",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz"
+                    },
+                    "minimatch": {
+                      "version": "3.0.3",
+                      "from": "minimatch@>=3.0.2 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
+                    },
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "minimist@0.0.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    },
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "from": "mkdirp@>=0.5.1 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+                    },
+                    "ms": {
+                      "version": "0.7.1",
+                      "from": "ms@0.7.1",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                    },
+                    "nopt": {
+                      "version": "3.0.6",
+                      "from": "nopt@>=3.0.6 <3.1.0",
+                      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz"
+                    },
+                    "npmlog": {
+                      "version": "4.0.2",
+                      "from": "npmlog@>=4.0.1 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz"
+                    },
+                    "number-is-nan": {
+                      "version": "1.0.1",
+                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+                    },
+                    "oauth-sign": {
+                      "version": "0.8.2",
+                      "from": "oauth-sign@>=0.8.1 <0.9.0",
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
+                    },
+                    "object-assign": {
+                      "version": "4.1.0",
+                      "from": "object-assign@>=4.1.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+                    },
+                    "once": {
+                      "version": "1.4.0",
+                      "from": "once@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.1",
+                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+                    },
+                    "pinkie": {
+                      "version": "2.0.4",
+                      "from": "pinkie@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                    },
+                    "pinkie-promise": {
+                      "version": "2.0.1",
+                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.7",
+                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                    },
+                    "punycode": {
+                      "version": "1.4.1",
+                      "from": "punycode@>=1.4.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+                    },
+                    "qs": {
+                      "version": "6.3.0",
+                      "from": "qs@>=6.3.0 <6.4.0",
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz"
+                    },
+                    "readable-stream": {
+                      "version": "2.2.2",
+                      "from": "readable-stream@>=2.0.0 <3.0.0||>=1.1.13 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+                    },
+                    "request": {
+                      "version": "2.79.0",
+                      "from": "request@>=2.79.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz"
+                    },
+                    "rimraf": {
+                      "version": "2.5.4",
+                      "from": "rimraf@>=2.5.4 <2.6.0",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz"
+                    },
+                    "semver": {
+                      "version": "5.3.0",
+                      "from": "semver@>=5.3.0 <5.4.0",
+                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
+                    },
+                    "set-blocking": {
+                      "version": "2.0.0",
+                      "from": "set-blocking@>=2.0.0 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
+                    },
+                    "signal-exit": {
+                      "version": "3.0.2",
+                      "from": "signal-exit@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "from": "sntp@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                    },
+                    "string-width": {
+                      "version": "1.0.2",
+                      "from": "string-width@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "stringstream": {
+                      "version": "0.0.5",
+                      "from": "stringstream@>=0.0.4 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "from": "strip-ansi@>=3.0.1 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+                    },
+                    "strip-json-comments": {
+                      "version": "1.0.4",
+                      "from": "strip-json-comments@>=1.0.4 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+                    },
+                    "tar": {
+                      "version": "2.2.1",
+                      "from": "tar@>=2.2.1 <2.3.0",
+                      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
+                    },
+                    "supports-color": {
+                      "version": "0.2.0",
+                      "from": "supports-color@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+                    },
+                    "tough-cookie": {
+                      "version": "2.3.2",
+                      "from": "tough-cookie@>=2.3.0 <2.4.0",
+                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz"
+                    },
+                    "tunnel-agent": {
+                      "version": "0.4.3",
+                      "from": "tunnel-agent@>=0.4.1 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
+                    },
+                    "tweetnacl": {
+                      "version": "0.14.5",
+                      "from": "tweetnacl@>=0.14.0 <0.15.0",
+                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+                    },
+                    "uid-number": {
+                      "version": "0.0.6",
+                      "from": "uid-number@>=0.0.6 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                    },
+                    "uuid": {
+                      "version": "3.0.1",
+                      "from": "uuid@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
+                    },
+                    "verror": {
+                      "version": "1.3.6",
+                      "from": "verror@1.3.6",
+                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                    },
+                    "wide-align": {
+                      "version": "1.1.0",
+                      "from": "wide-align@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz"
+                    },
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                    },
+                    "xtend": {
+                      "version": "4.0.1",
+                      "from": "xtend@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                    },
+                    "chalk": {
+                      "version": "1.1.3",
+                      "from": "chalk@>=1.1.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                      "dependencies": {
+                        "supports-color": {
+                          "version": "2.0.0",
+                          "from": "supports-color@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "dashdash": {
+                      "version": "1.14.1",
+                      "from": "dashdash@>=1.12.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "1.0.0",
+                          "from": "assert-plus@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "getpass": {
+                      "version": "0.1.6",
+                      "from": "getpass@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "1.0.0",
+                          "from": "assert-plus@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "rc": {
+                      "version": "1.1.6",
+                      "from": "rc@>=1.1.6 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "1.2.0",
+                          "from": "minimist@>=1.2.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                        }
+                      }
+                    },
+                    "sshpk": {
+                      "version": "1.10.1",
+                      "from": "sshpk@>=1.7.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "1.0.0",
+                          "from": "assert-plus@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "tar-pack": {
+                      "version": "3.3.0",
+                      "from": "tar-pack@>=3.3.0 <3.4.0",
+                      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.3.0.tgz",
+                      "dependencies": {
+                        "once": {
+                          "version": "1.3.3",
+                          "from": "once@>=1.3.3 <1.4.0",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+                        },
+                        "readable-stream": {
+                          "version": "2.1.5",
+                          "from": "readable-stream@>=2.1.4 <2.2.0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz"
+                        }
+                      }
+                    }
+                  }
                 }
               }
             },
@@ -4415,7 +5039,7 @@
               "dependencies": {
                 "camelcase": {
                   "version": "2.1.1",
-                  "from": "camelcase@>=2.0.0 <3.0.0",
+                  "from": "camelcase@>=2.0.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
                 },
                 "cliui": {
@@ -4425,7 +5049,7 @@
                   "dependencies": {
                     "strip-ansi": {
                       "version": "3.0.1",
-                      "from": "strip-ansi@>=3.0.0 <4.0.0",
+                      "from": "strip-ansi@>=3.0.1 <4.0.0",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                       "dependencies": {
                         "ansi-regex": {
@@ -5566,6 +6190,101 @@
         }
       }
     },
+    "nexmo": {
+      "version": "1.2.0",
+      "from": "nexmo@1.2.0",
+      "resolved": "https://registry.npmjs.org/nexmo/-/nexmo-1.2.0.tgz",
+      "dependencies": {
+        "jsonwebtoken": {
+          "version": "7.2.1",
+          "from": "jsonwebtoken@>=7.1.9 <8.0.0",
+          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-7.2.1.tgz",
+          "dependencies": {
+            "joi": {
+              "version": "6.10.1",
+              "from": "joi@>=6.10.1 <7.0.0",
+              "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
+              "dependencies": {
+                "hoek": {
+                  "version": "2.16.3",
+                  "from": "hoek@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                },
+                "topo": {
+                  "version": "1.1.0",
+                  "from": "topo@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz"
+                },
+                "isemail": {
+                  "version": "1.2.0",
+                  "from": "isemail@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz"
+                },
+                "moment": {
+                  "version": "2.17.1",
+                  "from": "moment@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/moment/-/moment-2.17.1.tgz"
+                }
+              }
+            },
+            "jws": {
+              "version": "3.1.4",
+              "from": "jws@>=3.1.4 <4.0.0",
+              "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.4.tgz",
+              "dependencies": {
+                "base64url": {
+                  "version": "2.0.0",
+                  "from": "base64url@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz"
+                },
+                "jwa": {
+                  "version": "1.1.5",
+                  "from": "jwa@>=1.1.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.5.tgz",
+                  "dependencies": {
+                    "buffer-equal-constant-time": {
+                      "version": "1.0.1",
+                      "from": "buffer-equal-constant-time@1.0.1",
+                      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz"
+                    },
+                    "ecdsa-sig-formatter": {
+                      "version": "1.0.9",
+                      "from": "ecdsa-sig-formatter@1.0.9",
+                      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.9.tgz"
+                    }
+                  }
+                },
+                "safe-buffer": {
+                  "version": "5.0.1",
+                  "from": "safe-buffer@>=5.0.1 <6.0.0",
+                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
+                }
+              }
+            },
+            "lodash.once": {
+              "version": "4.1.1",
+              "from": "lodash.once@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz"
+            },
+            "ms": {
+              "version": "0.7.2",
+              "from": "ms@>=0.7.1 <0.8.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+            },
+            "xtend": {
+              "version": "4.0.1",
+              "from": "xtend@>=4.0.1 <5.0.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+            }
+          }
+        },
+        "uuid": {
+          "version": "2.0.3",
+          "from": "uuid@>=2.0.2 <3.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz"
+        }
+      }
+    },
     "nodemailer": {
       "version": "2.7.2",
       "from": "nodemailer@2.7.2",
@@ -5938,7 +6657,7 @@
           "dependencies": {
             "chalk": {
               "version": "1.1.3",
-              "from": "chalk@>=1.1.1 <1.2.0",
+              "from": "chalk@>=1.1.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "dependencies": {
                 "ansi-styles": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "jed": "0.5.4",
     "moment-timezone": "0.5.11",
     "mozlog": "2.0.6",
+    "nexmo": "1.2.0",
     "nodemailer": "2.7.2",
     "po2json": "0.4.5",
     "poolee": "1.0.1",

--- a/scripts/write-to-disk.js
+++ b/scripts/write-to-disk.js
@@ -28,9 +28,9 @@
 
 var P = require('bluebird')
 var config = require('../config')
-var createMailer = require('../index')
+const createSenders = require('../index')
 var fs = require('fs')
-var log = require('../log')('server')
+const log = require('../legacy_log')(require('../log')('server'))
 var mkdirp = require('mkdirp')
 var path = require('path')
 
@@ -53,8 +53,9 @@ var mailSender = {
 }
 
 
-createMailer(log, config.getProperties(), mailSender)
-  .then((mailer) => {
+createSenders(log, config.getProperties(), mailSender)
+  .then((senders) => {
+    const mailer = senders.email
     checkMessageType(mailer, messageToSend)
 
     ensureTargetDirectoryExists()

--- a/templates/index.js
+++ b/templates/index.js
@@ -13,12 +13,16 @@ handlebars.registerHelper(
   }
 )
 
-function camelize(str) {
+function generateTemplateName (str) {
+  if (/^sms\.[A-Za-z]+/.test(str)) {
+    return str
+  }
+
   return str.replace(/_(.)/g,
     function(match, c) {
       return c.toUpperCase()
     }
-  )
+  ) + 'Email'
 }
 
 function loadTemplates(name) {
@@ -33,7 +37,7 @@ function loadTemplates(name) {
       var renderText = handlebars.compile(text)
       var renderHtml = handlebars.compile(html)
       return {
-        name: camelize(name) + 'Email',
+        name: generateTemplateName(name),
         fn: function (values) {
           return {
             text: renderText(values),
@@ -54,6 +58,7 @@ module.exports = function () {
       'password_reset_required',
       'post_verify',
       'recovery',
+      'sms.installFirefox',
       'unblock_code',
       'verification_reminder_first',
       'verification_reminder_second',

--- a/templates/sms.installFirefox.txt
+++ b/templates/sms.installFirefox.txt
@@ -1,0 +1,1 @@
+{{t "As requested, here is a link to install Firefox on your mobile device: %(link)s"}}

--- a/test/local/sms_tests.js
+++ b/test/local/sms_tests.js
@@ -1,0 +1,144 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+const P = require('bluebird')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+const test = require('tap').test
+
+const log = {
+  error: sinon.spy(),
+  info: sinon.spy(),
+  trace: sinon.spy()
+}
+
+let nexmoStatus = '0'
+const sendSms = sinon.spy((from, to, message, callback) => {
+  callback(null, {
+    message_count: '1',
+    messages: [
+      {
+        to: to.substr(1),
+        'message-id': 'foo',
+        status: nexmoStatus,
+        'error-text': 'bar',
+        'remaining-balance': '42',
+        'message-price': '1',
+        'network': 'baz'
+      }
+    ]
+  })
+})
+function Nexmo () {}
+Nexmo.prototype.message = { sendSms }
+
+P.all([
+  require('../../translator')(['en'], 'en'),
+  require('../../templates')()
+]).spread((translator, templates) => {
+  const sms = proxyquire('../../lib/sms', {
+    nexmo: Nexmo
+  })(log, translator, templates, {
+    apiKey: 'foo',
+    apiSecret: 'bar',
+    installFirefoxLink: 'https://baz/qux'
+  })
+
+  test('interface is correct', t => {
+    t.equal(typeof sms.send, 'function', 'sms.send is function')
+    t.equal(sms.send.length, 4, 'sms.send expects 4 arguments')
+    t.equal(Object.keys(sms).length, 1, 'sms has no other methods')
+    t.done()
+  })
+
+  test('send a valid sms', t => {
+    t.plan(13)
+    return sms.send('+442078553000', 'Firefox', 1, 'en')
+      .then(() => {
+        t.equal(sendSms.callCount, 1, 'nexmo.message.sendSms was called once')
+        const args = sendSms.args[0]
+        t.equal(args.length, 4, 'nexmo.message.sendSms was passed four arguments')
+        t.equal(args[0], 'Firefox', 'nexmo.message.sendSms was passed the correct sender id')
+        t.equal(args[1], '+442078553000', 'nexmo.message.sendSms was passed the correct phone number')
+        t.equal(args[2], 'As requested, here is a link to install Firefox on your mobile device: https://baz/qux', 'nexmo.message.sendSms was passed the correct message')
+        t.equal(typeof args[3], 'function', 'nexmo.message.sendSms was passed a callback function')
+
+        t.equal(log.trace.callCount, 1, 'log.trace was called once')
+        t.equal(log.trace.args[0].length, 1, 'log.trace was passed one argument')
+        t.deepEqual(log.trace.args[0][0], {
+          op: 'sms.send',
+          senderId: 'Firefox',
+          messageId: 1,
+          acceptLanguage: 'en'
+        }, 'log.info was passed the correct data')
+
+        t.equal(log.info.callCount, 1, 'log.info was called once')
+        t.equal(log.info.args[0].length, 1, 'log.info was passed one argument')
+        t.deepEqual(log.info.args[0][0], {
+          op: 'sms.send.success',
+          senderId: 'Firefox',
+          messageId: 1,
+          acceptLanguage: 'en'
+        }, 'log.info was passed the correct data')
+
+        t.equal(log.error.callCount, 0, 'log.error was not called')
+      })
+      .finally(() => {
+        sendSms.reset()
+        log.trace.reset()
+        log.info.reset()
+      })
+  })
+
+  test('try to send an sms with an invalid message id', t => {
+    t.plan(7)
+    return sms.send('+442078553000', 'Firefox', 2, 'en')
+      .then(() => t.notOk(true, 'sms.send should have rejected'))
+      .catch(error => {
+        t.equal(error.status, 400, 'error.statusCode was set correctly')
+        t.equal(error.message, 'Invalid message id', 'error.message was set correctly')
+
+        t.equal(log.trace.callCount, 1, 'log.trace was called once')
+        t.equal(log.info.callCount, 0, 'log.info was not called')
+
+        t.equal(log.error.callCount, 1, 'log.error was called once')
+        t.deepEqual(log.error.args[0][0], {
+          op: 'sms.send',
+          err: error.message
+        }, 'log.error was passed the correct data')
+
+        t.equal(sendSms.callCount, 0, 'nexmo.message.sendSms was not called')
+      })
+      .finally(() => {
+        log.trace.reset()
+        log.error.reset()
+      })
+  })
+
+  test('send an sms that is rejected by the network provider', t => {
+    t.plan(7)
+    nexmoStatus = '1'
+    return sms.send('+442078553000', 'Firefox', 1, 'en')
+      .then(() => t.notOk(true, 'sms.send should have rejected'))
+      .catch(error => {
+        t.equal(error.status, 500, 'error.statusCode was set correctly')
+        t.equal(error.message, 'Message rejected', 'error.message was set correctly')
+        t.equal(error.reason, 'bar', 'error.reason was set correctly')
+        t.equal(error.reasonCode, '1', 'error.reasonCode was set correctly')
+
+        t.equal(log.trace.callCount, 1, 'log.trace was called once')
+        t.equal(log.info.callCount, 0, 'log.info was not called')
+
+        t.equal(sendSms.callCount, 1, 'nexmo.message.sendSms was called once')
+      })
+      .finally(() => {
+        log.trace.reset()
+        sendSms.reset()
+        log.error.reset()
+      })
+  })
+})
+


### PR DESCRIPTION
Related to mozilla/fxa-auth-server#1628. Replaces #254.

This is broadly the same as the previous PR. The main difference is that I didn't realise the auth server invokes the mailer in-process before, so some redundant server nonsense has been removed. For the same reason, the interface for the package needed changing to return the `sms` module. I opted to return an object `{ email, sms }` but am open to other suggestions if anyone finds that offensive.

With the elimination of my imaginary server boundary, it made sense to pull the config and phone number validation up to the auth server level so those are both removed. And with the config gone, the `send-sms` script has moved over there too.

All that means the code here should be a bit simpler than it was. I think it's ready for review now but note that **we don't want to merge this until the auth server changes are also ready to be merged**. The aforementioned interface change requires equivalent changes in the auth server. 

You can see those auth server changes in the [phil/issue-1628 branch](https://github.com/mozilla/fxa-auth-server/compare/master...phil/issue-1628). I just need to sort out the correct sender id for USA/Canada and wire in the flow events before it, too, is ready to be reviewed.

@mozilla/fxa-devs r?