### PR TITLE
feat(sms): implement status check

### DIFF
--- a/lib/sms.js
+++ b/lib/sms.js
@@ -16,7 +16,8 @@ module.exports = function (log, translator, templates, smsConfig) {
     apiKey: smsConfig.apiKey,
     apiSecret: smsConfig.apiSecret
   })
-  var sendSms = P.promisify(nexmo.message.sendSms, { context: nexmo.message })
+  var sendSms = promisify('sendSms', nexmo.message)
+  var checkBalance = promisify('checkBalance', nexmo.account)
 
   return {
     send: function (phoneNumber, senderId, messageId, acceptLanguage) {
@@ -63,7 +64,25 @@ module.exports = function (log, translator, templates, smsConfig) {
             })
           }
         })
+    },
+
+    status: function () {
+      log.trace({ op: 'sms.status' })
+
+      return checkBalance()
+        .then(function (result) {
+          var balance = result.value
+          var isGood = balance >= smsConfig.balanceThreshold
+
+          log.info({ op: 'sms.status.success', balance: balance, isGood: isGood })
+
+          return { balance: balance, isGood: isGood }
+        })
     }
+  }
+
+  function promisify (methodName, object) {
+    return P.promisify(object[methodName], { context: object })
   }
 
   function getMessage (messageId, acceptLanguage) {


### PR DESCRIPTION
This is the auth mailer part of mozilla/fxa-auth-server#1646. It adds a method to check the balance of the nexmo account and indicate whether it's any good based on a threshold defined in config.

@mozilla/fxa-devs r?